### PR TITLE
0.2.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,5 +75,5 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: re.this/build/reports/kover/report.xml
+          files: rethis/build/reports/kover/report.xml
           verbose: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Re.this Changelog
 
+## 0.2.5
+
+* Moved `reconnectionStrategy` block in configuration to new `connection` block.
+* Added option to set connection source, `STANDALONE` or `POOL`, for all responses in config `connection` block, or for
+  transaction.
+* Added `shutdown` hook.
+
 ## 0.2.4
 
 * Enhanced the algorithm for parsing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# Re.this Changelog
+# Re.This Changelog
 
 ## 0.2.5
 
+* Change artifactId from `re.this` to `rethis`, to avoid problems with build on some platforms.
 * Moved `reconnectionStrategy` block in configuration to new `connection` block.
 * Added option to set connection source, `STANDALONE` or `POOL`, for all responses in config `connection` block, or for
   transaction.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use Re.This in your project, add the following dependency to your Gradle buil
 
 ```gradle
 dependencies {
-    implementation("eu.vendeli:re.this:0.2.3")
+    implementation("eu.vendeli:rethis:0.2.3")
 }
 ```
 

--- a/api/re.this.api
+++ b/api/re.this.api
@@ -12,7 +12,8 @@ public final class eu/vendeli/rethis/ReThis {
 	public final fun isDisconnected ()Z
 	public final fun pipeline (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun reconnect ()V
-	public final fun transaction (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun transaction (Leu/vendeli/rethis/types/core/ConnectionSource;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun transaction$default (Leu/vendeli/rethis/ReThis;Leu/vendeli/rethis/types/core/ConnectionSource;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class eu/vendeli/rethis/ReThisException : java/lang/RuntimeException {
@@ -782,27 +783,55 @@ public final class eu/vendeli/rethis/types/core/BulkString : eu/vendeli/rethis/t
 
 public final class eu/vendeli/rethis/types/core/ClientConfiguration {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/PoolConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;)V
-	public synthetic fun <init> (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/PoolConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun auth (Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun auth$default (Leu/vendeli/rethis/types/core/ClientConfiguration;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun component1 ()Ljava/lang/Integer;
 	public final fun component2 ()Ljava/nio/charset/Charset;
 	public final fun component3 ()Lio/ktor/network/tls/TLSConfig;
-	public final fun copy (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/PoolConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;)Leu/vendeli/rethis/types/core/ClientConfiguration;
-	public static synthetic fun copy$default (Leu/vendeli/rethis/types/core/ClientConfiguration;Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/PoolConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;ILjava/lang/Object;)Leu/vendeli/rethis/types/core/ClientConfiguration;
+	public final fun connection (Lkotlin/jvm/functions/Function1;)V
+	public final fun copy (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;)Leu/vendeli/rethis/types/core/ClientConfiguration;
+	public static synthetic fun copy$default (Leu/vendeli/rethis/types/core/ClientConfiguration;Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;ILjava/lang/Object;)Leu/vendeli/rethis/types/core/ClientConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCharset ()Ljava/nio/charset/Charset;
 	public final fun getDb ()Ljava/lang/Integer;
 	public final fun getTlsConfig ()Lio/ktor/network/tls/TLSConfig;
 	public fun hashCode ()I
-	public final fun pool (Lkotlin/jvm/functions/Function1;)V
 	public final fun reconnectionStrategy (Lkotlin/jvm/functions/Function1;)V
 	public final fun setCharset (Ljava/nio/charset/Charset;)V
 	public final fun setDb (Ljava/lang/Integer;)V
 	public final fun setTlsConfig (Lio/ktor/network/tls/TLSConfig;)V
 	public final fun socket (Lkotlin/jvm/functions/Function1;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/rethis/types/core/ConnectionConfiguration {
+	public fun <init> ()V
+	public fun <init> (Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;)V
+	public synthetic fun <init> (Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Leu/vendeli/rethis/types/core/ConnectionSource;
+	public final fun component2 ()I
+	public final fun component3 ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun copy (Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;)Leu/vendeli/rethis/types/core/ConnectionConfiguration;
+	public static synthetic fun copy$default (Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Leu/vendeli/rethis/types/core/ConnectionConfiguration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultConnectionSource ()Leu/vendeli/rethis/types/core/ConnectionSource;
+	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun getPoolSize ()I
+	public fun hashCode ()I
+	public final fun setDefaultConnectionSource (Leu/vendeli/rethis/types/core/ConnectionSource;)V
+	public final fun setDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
+	public final fun setPoolSize (I)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/rethis/types/core/ConnectionSource : java/lang/Enum {
+	public static final field POOL Leu/vendeli/rethis/types/core/ConnectionSource;
+	public static final field STANDALONE Leu/vendeli/rethis/types/core/ConnectionSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Leu/vendeli/rethis/types/core/ConnectionSource;
+	public static fun values ()[Leu/vendeli/rethis/types/core/ConnectionSource;
 }
 
 public final class eu/vendeli/rethis/types/core/DoubleArg : eu/vendeli/rethis/types/core/Argument {
@@ -885,23 +914,6 @@ public final class eu/vendeli/rethis/types/core/PlainString : eu/vendeli/rethis/
 	public synthetic fun getValue ()Ljava/lang/Object;
 	public fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class eu/vendeli/rethis/types/core/PoolConfiguration {
-	public fun <init> ()V
-	public fun <init> (ILkotlinx/coroutines/CoroutineDispatcher;)V
-	public synthetic fun <init> (ILkotlinx/coroutines/CoroutineDispatcher;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()I
-	public final fun component2 ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public final fun copy (ILkotlinx/coroutines/CoroutineDispatcher;)Leu/vendeli/rethis/types/core/PoolConfiguration;
-	public static synthetic fun copy$default (Leu/vendeli/rethis/types/core/PoolConfiguration;ILkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Leu/vendeli/rethis/types/core/PoolConfiguration;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public final fun getPoolSize ()I
-	public fun hashCode ()I
-	public final fun setDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
-	public final fun setPoolSize (I)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -1827,6 +1839,10 @@ public final class eu/vendeli/rethis/types/options/ZRangeOption$LIMIT : eu/vende
 }
 
 public abstract class eu/vendeli/rethis/types/options/ZRangeOption$Type : eu/vendeli/rethis/types/options/ZRangeOption {
+}
+
+public final class eu/vendeli/rethis/utils/CommonUtilsKt {
+	public static final fun isOk (Leu/vendeli/rethis/types/core/RType;)Z
 }
 
 public final class eu/vendeli/rethis/wrappers/ReThisMap : kotlin/collections/AbstractMutableMap {

--- a/api/re.this.api
+++ b/api/re.this.api
@@ -12,6 +12,7 @@ public final class eu/vendeli/rethis/ReThis {
 	public final fun isDisconnected ()Z
 	public final fun pipeline (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun reconnect ()V
+	public final fun shutdown ()V
 	public final fun transaction (Leu/vendeli/rethis/types/core/ConnectionSource;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun transaction$default (Leu/vendeli/rethis/ReThis;Leu/vendeli/rethis/types/core/ConnectionSource;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
@@ -783,22 +784,21 @@ public final class eu/vendeli/rethis/types/core/BulkString : eu/vendeli/rethis/t
 
 public final class eu/vendeli/rethis/types/core/ClientConfiguration {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;)V
-	public synthetic fun <init> (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun auth (Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun auth$default (Leu/vendeli/rethis/types/core/ClientConfiguration;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun component1 ()Ljava/lang/Integer;
 	public final fun component2 ()Ljava/nio/charset/Charset;
 	public final fun component3 ()Lio/ktor/network/tls/TLSConfig;
 	public final fun connection (Lkotlin/jvm/functions/Function1;)V
-	public final fun copy (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;)Leu/vendeli/rethis/types/core/ClientConfiguration;
-	public static synthetic fun copy$default (Leu/vendeli/rethis/types/core/ClientConfiguration;Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;ILjava/lang/Object;)Leu/vendeli/rethis/types/core/ClientConfiguration;
+	public final fun copy (Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;)Leu/vendeli/rethis/types/core/ClientConfiguration;
+	public static synthetic fun copy$default (Leu/vendeli/rethis/types/core/ClientConfiguration;Ljava/lang/Integer;Ljava/nio/charset/Charset;Lio/ktor/network/tls/TLSConfig;Leu/vendeli/rethis/types/core/AuthConfiguration;Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/SocketConfiguration;ILjava/lang/Object;)Leu/vendeli/rethis/types/core/ClientConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCharset ()Ljava/nio/charset/Charset;
 	public final fun getDb ()Ljava/lang/Integer;
 	public final fun getTlsConfig ()Lio/ktor/network/tls/TLSConfig;
 	public fun hashCode ()I
-	public final fun reconnectionStrategy (Lkotlin/jvm/functions/Function1;)V
 	public final fun setCharset (Ljava/nio/charset/Charset;)V
 	public final fun setDb (Ljava/lang/Integer;)V
 	public final fun setTlsConfig (Lio/ktor/network/tls/TLSConfig;)V
@@ -808,21 +808,27 @@ public final class eu/vendeli/rethis/types/core/ClientConfiguration {
 
 public final class eu/vendeli/rethis/types/core/ConnectionConfiguration {
 	public fun <init> ()V
-	public fun <init> (Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;)V
-	public synthetic fun <init> (Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;IJ)V
+	public synthetic fun <init> (Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Leu/vendeli/rethis/types/core/ConnectionSource;
 	public final fun component2 ()I
 	public final fun component3 ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public final fun copy (Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;)Leu/vendeli/rethis/types/core/ConnectionConfiguration;
-	public static synthetic fun copy$default (Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Leu/vendeli/rethis/types/core/ConnectionConfiguration;
+	public final fun component4 ()I
+	public final fun component5 ()J
+	public final fun copy (Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;IJ)Leu/vendeli/rethis/types/core/ConnectionConfiguration;
+	public static synthetic fun copy$default (Leu/vendeli/rethis/types/core/ConnectionConfiguration;Leu/vendeli/rethis/types/core/ConnectionSource;ILkotlinx/coroutines/CoroutineDispatcher;IJILjava/lang/Object;)Leu/vendeli/rethis/types/core/ConnectionConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDefaultConnectionSource ()Leu/vendeli/rethis/types/core/ConnectionSource;
 	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getPoolSize ()I
+	public final fun getReconnectAttempts ()I
+	public final fun getReconnectDelay ()J
 	public fun hashCode ()I
 	public final fun setDefaultConnectionSource (Leu/vendeli/rethis/types/core/ConnectionSource;)V
 	public final fun setDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public final fun setPoolSize (I)V
+	public final fun setReconnectAttempts (I)V
+	public final fun setReconnectDelay (J)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -994,26 +1000,6 @@ public final class eu/vendeli/rethis/types/core/RType$Null : eu/vendeli/rethis/t
 public final class eu/vendeli/rethis/types/core/RType$Raw : eu/vendeli/rethis/types/core/RType {
 	public synthetic fun getValue ()Ljava/lang/Object;
 	public fun getValue ()[B
-}
-
-public final class eu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration {
-	public fun <init> ()V
-	public fun <init> (ZIJ)V
-	public synthetic fun <init> (ZIJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Z
-	public final fun component2 ()I
-	public final fun component3 ()J
-	public final fun copy (ZIJ)Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;
-	public static synthetic fun copy$default (Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;ZIJILjava/lang/Object;)Leu/vendeli/rethis/types/core/ReconnectionStrategyConfiguration;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getDoHealthCheck ()Z
-	public final fun getReconnectAttempts ()I
-	public final fun getReconnectDelay ()J
-	public fun hashCode ()I
-	public final fun setDoHealthCheck (Z)V
-	public final fun setReconnectAttempts (I)V
-	public final fun setReconnectDelay (J)V
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class eu/vendeli/rethis/types/core/RespVer {

--- a/api/re.this.api
+++ b/api/re.this.api
@@ -947,6 +947,28 @@ public final class eu/vendeli/rethis/types/core/RArray : eu/vendeli/rethis/types
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class eu/vendeli/rethis/types/core/RConnection {
+	public fun <init> (Lio/ktor/network/sockets/Socket;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Lkotlinx/coroutines/sync/Mutex;)V
+	public synthetic fun <init> (Lio/ktor/network/sockets/Socket;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Lkotlinx/coroutines/sync/Mutex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/ktor/network/sockets/Socket;
+	public final fun component2 ()Lio/ktor/utils/io/ByteReadChannel;
+	public final fun component3 ()Lio/ktor/utils/io/ByteWriteChannel;
+	public final fun component4 ()Lkotlinx/coroutines/sync/Mutex;
+	public final fun copy (Lio/ktor/network/sockets/Socket;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Lkotlinx/coroutines/sync/Mutex;)Leu/vendeli/rethis/types/core/RConnection;
+	public static synthetic fun copy$default (Leu/vendeli/rethis/types/core/RConnection;Lio/ktor/network/sockets/Socket;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Lkotlinx/coroutines/sync/Mutex;ILjava/lang/Object;)Leu/vendeli/rethis/types/core/RConnection;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInput ()Lio/ktor/utils/io/ByteReadChannel;
+	public final fun getOutput ()Lio/ktor/utils/io/ByteWriteChannel;
+	public final fun getSocket ()Lio/ktor/network/sockets/Socket;
+	public final fun getStatus ()Lkotlinx/coroutines/sync/Mutex;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/rethis/types/core/RConnectionKt {
+	public static final fun rConnection (Lio/ktor/network/sockets/Socket;)Leu/vendeli/rethis/types/core/RConnection;
+}
+
 public final class eu/vendeli/rethis/types/core/RMap : eu/vendeli/rethis/types/core/RType {
 	public fun <init> (Ljava/util/Map;)V
 	public final fun component1 ()Ljava/util/Map;
@@ -1085,8 +1107,8 @@ public final class eu/vendeli/rethis/types/core/VerbatimString : eu/vendeli/reth
 
 public final class eu/vendeli/rethis/types/coroutine/CoLocalConn : kotlin/coroutines/AbstractCoroutineContextElement, kotlin/coroutines/CoroutineContext$Element {
 	public static final field Key Leu/vendeli/rethis/types/coroutine/CoLocalConn$Key;
-	public fun <init> (Lio/ktor/network/sockets/Connection;)V
-	public final fun getConnection ()Lio/ktor/network/sockets/Connection;
+	public fun <init> (Leu/vendeli/rethis/types/core/RConnection;)V
+	public final fun getConnection ()Leu/vendeli/rethis/types/core/RConnection;
 	public fun getKey ()Leu/vendeli/rethis/types/coroutine/CoLocalConn$Key;
 	public synthetic fun getKey ()Lkotlin/coroutines/CoroutineContext$Key;
 }

--- a/api/re.this.klib.api
+++ b/api/re.this.klib.api
@@ -636,6 +636,28 @@ final class eu.vendeli.rethis.types.core/RArray : eu.vendeli.rethis.types.core/R
     final fun toString(): kotlin/String // eu.vendeli.rethis.types.core/RArray.toString|toString(){}[0]
 }
 
+final class eu.vendeli.rethis.types.core/RConnection { // eu.vendeli.rethis.types.core/RConnection|null[0]
+    constructor <init>(io.ktor.network.sockets/Socket, io.ktor.utils.io/ByteReadChannel, io.ktor.utils.io/ByteWriteChannel, kotlinx.coroutines.sync/Mutex = ...) // eu.vendeli.rethis.types.core/RConnection.<init>|<init>(io.ktor.network.sockets.Socket;io.ktor.utils.io.ByteReadChannel;io.ktor.utils.io.ByteWriteChannel;kotlinx.coroutines.sync.Mutex){}[0]
+
+    final val input // eu.vendeli.rethis.types.core/RConnection.input|{}input[0]
+        final fun <get-input>(): io.ktor.utils.io/ByteReadChannel // eu.vendeli.rethis.types.core/RConnection.input.<get-input>|<get-input>(){}[0]
+    final val output // eu.vendeli.rethis.types.core/RConnection.output|{}output[0]
+        final fun <get-output>(): io.ktor.utils.io/ByteWriteChannel // eu.vendeli.rethis.types.core/RConnection.output.<get-output>|<get-output>(){}[0]
+    final val socket // eu.vendeli.rethis.types.core/RConnection.socket|{}socket[0]
+        final fun <get-socket>(): io.ktor.network.sockets/Socket // eu.vendeli.rethis.types.core/RConnection.socket.<get-socket>|<get-socket>(){}[0]
+    final val status // eu.vendeli.rethis.types.core/RConnection.status|{}status[0]
+        final fun <get-status>(): kotlinx.coroutines.sync/Mutex // eu.vendeli.rethis.types.core/RConnection.status.<get-status>|<get-status>(){}[0]
+
+    final fun component1(): io.ktor.network.sockets/Socket // eu.vendeli.rethis.types.core/RConnection.component1|component1(){}[0]
+    final fun component2(): io.ktor.utils.io/ByteReadChannel // eu.vendeli.rethis.types.core/RConnection.component2|component2(){}[0]
+    final fun component3(): io.ktor.utils.io/ByteWriteChannel // eu.vendeli.rethis.types.core/RConnection.component3|component3(){}[0]
+    final fun component4(): kotlinx.coroutines.sync/Mutex // eu.vendeli.rethis.types.core/RConnection.component4|component4(){}[0]
+    final fun copy(io.ktor.network.sockets/Socket = ..., io.ktor.utils.io/ByteReadChannel = ..., io.ktor.utils.io/ByteWriteChannel = ..., kotlinx.coroutines.sync/Mutex = ...): eu.vendeli.rethis.types.core/RConnection // eu.vendeli.rethis.types.core/RConnection.copy|copy(io.ktor.network.sockets.Socket;io.ktor.utils.io.ByteReadChannel;io.ktor.utils.io.ByteWriteChannel;kotlinx.coroutines.sync.Mutex){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // eu.vendeli.rethis.types.core/RConnection.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // eu.vendeli.rethis.types.core/RConnection.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // eu.vendeli.rethis.types.core/RConnection.toString|toString(){}[0]
+}
+
 final class eu.vendeli.rethis.types.core/RMap : eu.vendeli.rethis.types.core/RType { // eu.vendeli.rethis.types.core/RMap|null[0]
     constructor <init>(kotlin.collections/Map<eu.vendeli.rethis.types.core/RPrimitive, eu.vendeli.rethis.types.core/RType?>) // eu.vendeli.rethis.types.core/RMap.<init>|<init>(kotlin.collections.Map<eu.vendeli.rethis.types.core.RPrimitive,eu.vendeli.rethis.types.core.RType?>){}[0]
 
@@ -715,10 +737,10 @@ final class eu.vendeli.rethis.types.core/VerbatimString : eu.vendeli.rethis.type
 }
 
 final class eu.vendeli.rethis.types.coroutine/CoLocalConn : kotlin.coroutines/AbstractCoroutineContextElement, kotlin.coroutines/CoroutineContext.Element { // eu.vendeli.rethis.types.coroutine/CoLocalConn|null[0]
-    constructor <init>(io.ktor.network.sockets/Connection) // eu.vendeli.rethis.types.coroutine/CoLocalConn.<init>|<init>(io.ktor.network.sockets.Connection){}[0]
+    constructor <init>(eu.vendeli.rethis.types.core/RConnection) // eu.vendeli.rethis.types.coroutine/CoLocalConn.<init>|<init>(eu.vendeli.rethis.types.core.RConnection){}[0]
 
     final val connection // eu.vendeli.rethis.types.coroutine/CoLocalConn.connection|{}connection[0]
-        final fun <get-connection>(): io.ktor.network.sockets/Connection // eu.vendeli.rethis.types.coroutine/CoLocalConn.connection.<get-connection>|<get-connection>(){}[0]
+        final fun <get-connection>(): eu.vendeli.rethis.types.core/RConnection // eu.vendeli.rethis.types.coroutine/CoLocalConn.connection.<get-connection>|<get-connection>(){}[0]
     final val key // eu.vendeli.rethis.types.coroutine/CoLocalConn.key|{}key[0]
         final fun <get-key>(): eu.vendeli.rethis.types.coroutine/CoLocalConn.Key // eu.vendeli.rethis.types.coroutine/CoLocalConn.key.<get-key>|<get-key>(){}[0]
 
@@ -1635,6 +1657,7 @@ final object eu.vendeli.rethis.types.options/WITHMATCHLEN : eu.vendeli.rethis.ty
 final fun (eu.vendeli.rethis.types.core/RType).eu.vendeli.rethis.utils/isOk(): kotlin/Boolean // eu.vendeli.rethis.utils/isOk|isOk@eu.vendeli.rethis.types.core.RType(){}[0]
 final fun (eu.vendeli.rethis/ReThis).eu.vendeli.rethis.wrappers/Hash(kotlin/String): eu.vendeli.rethis.wrappers/ReThisMap // eu.vendeli.rethis.wrappers/Hash|Hash@eu.vendeli.rethis.ReThis(kotlin.String){}[0]
 final fun (eu.vendeli.rethis/ReThis).eu.vendeli.rethis.wrappers/Set(kotlin/String): eu.vendeli.rethis.wrappers/ReThisSet // eu.vendeli.rethis.wrappers/Set|Set@eu.vendeli.rethis.ReThis(kotlin.String){}[0]
+final fun (io.ktor.network.sockets/Socket).eu.vendeli.rethis.types.core/rConnection(): eu.vendeli.rethis.types.core/RConnection // eu.vendeli.rethis.types.core/rConnection|rConnection@io.ktor.network.sockets.Socket(){}[0]
 final fun (kotlin/Any).eu.vendeli.rethis.types.core/toArg(): eu.vendeli.rethis.types.core/Argument // eu.vendeli.rethis.types.core/toArg|toArg@kotlin.Any(){}[0]
 final inline fun (kotlin.collections/List<kotlin/Any>).eu.vendeli.rethis.types.core/toArg(): kotlin.collections/List<eu.vendeli.rethis.types.core/Argument> // eu.vendeli.rethis.types.core/toArg|toArg@kotlin.collections.List<kotlin.Any>(){}[0]
 final suspend fun (eu.vendeli.rethis/ReThis).eu.vendeli.rethis.commands/append(kotlin/String, kotlin/String): kotlin/Long // eu.vendeli.rethis.commands/append|append@eu.vendeli.rethis.ReThis(kotlin.String;kotlin.String){}[0]

--- a/api/re.this.klib.api
+++ b/api/re.this.klib.api
@@ -54,6 +54,17 @@ final enum class eu.vendeli.rethis.types.common/MoveDirection : kotlin/Enum<eu.v
     final fun values(): kotlin/Array<eu.vendeli.rethis.types.common/MoveDirection> // eu.vendeli.rethis.types.common/MoveDirection.values|values#static(){}[0]
 }
 
+final enum class eu.vendeli.rethis.types.core/ConnectionSource : kotlin/Enum<eu.vendeli.rethis.types.core/ConnectionSource> { // eu.vendeli.rethis.types.core/ConnectionSource|null[0]
+    enum entry POOL // eu.vendeli.rethis.types.core/ConnectionSource.POOL|null[0]
+    enum entry STANDALONE // eu.vendeli.rethis.types.core/ConnectionSource.STANDALONE|null[0]
+
+    final val entries // eu.vendeli.rethis.types.core/ConnectionSource.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<eu.vendeli.rethis.types.core/ConnectionSource> // eu.vendeli.rethis.types.core/ConnectionSource.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): eu.vendeli.rethis.types.core/ConnectionSource // eu.vendeli.rethis.types.core/ConnectionSource.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<eu.vendeli.rethis.types.core/ConnectionSource> // eu.vendeli.rethis.types.core/ConnectionSource.values|values#static(){}[0]
+}
+
 final enum class eu.vendeli.rethis.types.options/BitmapDataType : kotlin/Enum<eu.vendeli.rethis.types.options/BitmapDataType> { // eu.vendeli.rethis.types.options/BitmapDataType|null[0]
     enum entry BIT // eu.vendeli.rethis.types.options/BitmapDataType.BIT|null[0]
     enum entry BYTE // eu.vendeli.rethis.types.options/BitmapDataType.BYTE|null[0]
@@ -502,7 +513,7 @@ final class eu.vendeli.rethis.types.core/BulkString : eu.vendeli.rethis.types.co
 }
 
 final class eu.vendeli.rethis.types.core/ClientConfiguration { // eu.vendeli.rethis.types.core/ClientConfiguration|null[0]
-    constructor <init>(kotlin/Int? = ..., io.ktor.utils.io.charsets/Charset = ..., io.ktor.network.tls/TLSConfig? = ..., eu.vendeli.rethis.types.core/AuthConfiguration? = ..., eu.vendeli.rethis.types.core/PoolConfiguration = ..., eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration = ..., eu.vendeli.rethis.types.core/SocketConfiguration = ...) // eu.vendeli.rethis.types.core/ClientConfiguration.<init>|<init>(kotlin.Int?;io.ktor.utils.io.charsets.Charset;io.ktor.network.tls.TLSConfig?;eu.vendeli.rethis.types.core.AuthConfiguration?;eu.vendeli.rethis.types.core.PoolConfiguration;eu.vendeli.rethis.types.core.ReconnectionStrategyConfiguration;eu.vendeli.rethis.types.core.SocketConfiguration){}[0]
+    constructor <init>(kotlin/Int? = ..., io.ktor.utils.io.charsets/Charset = ..., io.ktor.network.tls/TLSConfig? = ..., eu.vendeli.rethis.types.core/AuthConfiguration? = ..., eu.vendeli.rethis.types.core/ConnectionConfiguration = ..., eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration = ..., eu.vendeli.rethis.types.core/SocketConfiguration = ...) // eu.vendeli.rethis.types.core/ClientConfiguration.<init>|<init>(kotlin.Int?;io.ktor.utils.io.charsets.Charset;io.ktor.network.tls.TLSConfig?;eu.vendeli.rethis.types.core.AuthConfiguration?;eu.vendeli.rethis.types.core.ConnectionConfiguration;eu.vendeli.rethis.types.core.ReconnectionStrategyConfiguration;eu.vendeli.rethis.types.core.SocketConfiguration){}[0]
 
     final var charset // eu.vendeli.rethis.types.core/ClientConfiguration.charset|{}charset[0]
         final fun <get-charset>(): io.ktor.utils.io.charsets/Charset // eu.vendeli.rethis.types.core/ClientConfiguration.charset.<get-charset>|<get-charset>(){}[0]
@@ -518,13 +529,35 @@ final class eu.vendeli.rethis.types.core/ClientConfiguration { // eu.vendeli.ret
     final fun component1(): kotlin/Int? // eu.vendeli.rethis.types.core/ClientConfiguration.component1|component1(){}[0]
     final fun component2(): io.ktor.utils.io.charsets/Charset // eu.vendeli.rethis.types.core/ClientConfiguration.component2|component2(){}[0]
     final fun component3(): io.ktor.network.tls/TLSConfig? // eu.vendeli.rethis.types.core/ClientConfiguration.component3|component3(){}[0]
-    final fun copy(kotlin/Int? = ..., io.ktor.utils.io.charsets/Charset = ..., io.ktor.network.tls/TLSConfig? = ..., eu.vendeli.rethis.types.core/AuthConfiguration? = ..., eu.vendeli.rethis.types.core/PoolConfiguration = ..., eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration = ..., eu.vendeli.rethis.types.core/SocketConfiguration = ...): eu.vendeli.rethis.types.core/ClientConfiguration // eu.vendeli.rethis.types.core/ClientConfiguration.copy|copy(kotlin.Int?;io.ktor.utils.io.charsets.Charset;io.ktor.network.tls.TLSConfig?;eu.vendeli.rethis.types.core.AuthConfiguration?;eu.vendeli.rethis.types.core.PoolConfiguration;eu.vendeli.rethis.types.core.ReconnectionStrategyConfiguration;eu.vendeli.rethis.types.core.SocketConfiguration){}[0]
+    final fun connection(kotlin/Function1<eu.vendeli.rethis.types.core/ConnectionConfiguration, kotlin/Unit>) // eu.vendeli.rethis.types.core/ClientConfiguration.connection|connection(kotlin.Function1<eu.vendeli.rethis.types.core.ConnectionConfiguration,kotlin.Unit>){}[0]
+    final fun copy(kotlin/Int? = ..., io.ktor.utils.io.charsets/Charset = ..., io.ktor.network.tls/TLSConfig? = ..., eu.vendeli.rethis.types.core/AuthConfiguration? = ..., eu.vendeli.rethis.types.core/ConnectionConfiguration = ..., eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration = ..., eu.vendeli.rethis.types.core/SocketConfiguration = ...): eu.vendeli.rethis.types.core/ClientConfiguration // eu.vendeli.rethis.types.core/ClientConfiguration.copy|copy(kotlin.Int?;io.ktor.utils.io.charsets.Charset;io.ktor.network.tls.TLSConfig?;eu.vendeli.rethis.types.core.AuthConfiguration?;eu.vendeli.rethis.types.core.ConnectionConfiguration;eu.vendeli.rethis.types.core.ReconnectionStrategyConfiguration;eu.vendeli.rethis.types.core.SocketConfiguration){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // eu.vendeli.rethis.types.core/ClientConfiguration.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // eu.vendeli.rethis.types.core/ClientConfiguration.hashCode|hashCode(){}[0]
-    final fun pool(kotlin/Function1<eu.vendeli.rethis.types.core/PoolConfiguration, kotlin/Unit>) // eu.vendeli.rethis.types.core/ClientConfiguration.pool|pool(kotlin.Function1<eu.vendeli.rethis.types.core.PoolConfiguration,kotlin.Unit>){}[0]
     final fun reconnectionStrategy(kotlin/Function1<eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration, kotlin/Unit>) // eu.vendeli.rethis.types.core/ClientConfiguration.reconnectionStrategy|reconnectionStrategy(kotlin.Function1<eu.vendeli.rethis.types.core.ReconnectionStrategyConfiguration,kotlin.Unit>){}[0]
     final fun socket(kotlin/Function1<eu.vendeli.rethis.types.core/SocketConfiguration, kotlin/Unit>) // eu.vendeli.rethis.types.core/ClientConfiguration.socket|socket(kotlin.Function1<eu.vendeli.rethis.types.core.SocketConfiguration,kotlin.Unit>){}[0]
     final fun toString(): kotlin/String // eu.vendeli.rethis.types.core/ClientConfiguration.toString|toString(){}[0]
+}
+
+final class eu.vendeli.rethis.types.core/ConnectionConfiguration { // eu.vendeli.rethis.types.core/ConnectionConfiguration|null[0]
+    constructor <init>(eu.vendeli.rethis.types.core/ConnectionSource = ..., kotlin/Int = ..., kotlinx.coroutines/CoroutineDispatcher = ...) // eu.vendeli.rethis.types.core/ConnectionConfiguration.<init>|<init>(eu.vendeli.rethis.types.core.ConnectionSource;kotlin.Int;kotlinx.coroutines.CoroutineDispatcher){}[0]
+
+    final var defaultConnectionSource // eu.vendeli.rethis.types.core/ConnectionConfiguration.defaultConnectionSource|{}defaultConnectionSource[0]
+        final fun <get-defaultConnectionSource>(): eu.vendeli.rethis.types.core/ConnectionSource // eu.vendeli.rethis.types.core/ConnectionConfiguration.defaultConnectionSource.<get-defaultConnectionSource>|<get-defaultConnectionSource>(){}[0]
+        final fun <set-defaultConnectionSource>(eu.vendeli.rethis.types.core/ConnectionSource) // eu.vendeli.rethis.types.core/ConnectionConfiguration.defaultConnectionSource.<set-defaultConnectionSource>|<set-defaultConnectionSource>(eu.vendeli.rethis.types.core.ConnectionSource){}[0]
+    final var dispatcher // eu.vendeli.rethis.types.core/ConnectionConfiguration.dispatcher|{}dispatcher[0]
+        final fun <get-dispatcher>(): kotlinx.coroutines/CoroutineDispatcher // eu.vendeli.rethis.types.core/ConnectionConfiguration.dispatcher.<get-dispatcher>|<get-dispatcher>(){}[0]
+        final fun <set-dispatcher>(kotlinx.coroutines/CoroutineDispatcher) // eu.vendeli.rethis.types.core/ConnectionConfiguration.dispatcher.<set-dispatcher>|<set-dispatcher>(kotlinx.coroutines.CoroutineDispatcher){}[0]
+    final var poolSize // eu.vendeli.rethis.types.core/ConnectionConfiguration.poolSize|{}poolSize[0]
+        final fun <get-poolSize>(): kotlin/Int // eu.vendeli.rethis.types.core/ConnectionConfiguration.poolSize.<get-poolSize>|<get-poolSize>(){}[0]
+        final fun <set-poolSize>(kotlin/Int) // eu.vendeli.rethis.types.core/ConnectionConfiguration.poolSize.<set-poolSize>|<set-poolSize>(kotlin.Int){}[0]
+
+    final fun component1(): eu.vendeli.rethis.types.core/ConnectionSource // eu.vendeli.rethis.types.core/ConnectionConfiguration.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // eu.vendeli.rethis.types.core/ConnectionConfiguration.component2|component2(){}[0]
+    final fun component3(): kotlinx.coroutines/CoroutineDispatcher // eu.vendeli.rethis.types.core/ConnectionConfiguration.component3|component3(){}[0]
+    final fun copy(eu.vendeli.rethis.types.core/ConnectionSource = ..., kotlin/Int = ..., kotlinx.coroutines/CoroutineDispatcher = ...): eu.vendeli.rethis.types.core/ConnectionConfiguration // eu.vendeli.rethis.types.core/ConnectionConfiguration.copy|copy(eu.vendeli.rethis.types.core.ConnectionSource;kotlin.Int;kotlinx.coroutines.CoroutineDispatcher){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // eu.vendeli.rethis.types.core/ConnectionConfiguration.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // eu.vendeli.rethis.types.core/ConnectionConfiguration.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // eu.vendeli.rethis.types.core/ConnectionConfiguration.toString|toString(){}[0]
 }
 
 final class eu.vendeli.rethis.types.core/F64 : eu.vendeli.rethis.types.core/RPrimitive { // eu.vendeli.rethis.types.core/F64|null[0]
@@ -568,24 +601,6 @@ final class eu.vendeli.rethis.types.core/PlainString : eu.vendeli.rethis.types.c
     final fun equals(kotlin/Any?): kotlin/Boolean // eu.vendeli.rethis.types.core/PlainString.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // eu.vendeli.rethis.types.core/PlainString.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // eu.vendeli.rethis.types.core/PlainString.toString|toString(){}[0]
-}
-
-final class eu.vendeli.rethis.types.core/PoolConfiguration { // eu.vendeli.rethis.types.core/PoolConfiguration|null[0]
-    constructor <init>(kotlin/Int = ..., kotlinx.coroutines/CoroutineDispatcher = ...) // eu.vendeli.rethis.types.core/PoolConfiguration.<init>|<init>(kotlin.Int;kotlinx.coroutines.CoroutineDispatcher){}[0]
-
-    final var dispatcher // eu.vendeli.rethis.types.core/PoolConfiguration.dispatcher|{}dispatcher[0]
-        final fun <get-dispatcher>(): kotlinx.coroutines/CoroutineDispatcher // eu.vendeli.rethis.types.core/PoolConfiguration.dispatcher.<get-dispatcher>|<get-dispatcher>(){}[0]
-        final fun <set-dispatcher>(kotlinx.coroutines/CoroutineDispatcher) // eu.vendeli.rethis.types.core/PoolConfiguration.dispatcher.<set-dispatcher>|<set-dispatcher>(kotlinx.coroutines.CoroutineDispatcher){}[0]
-    final var poolSize // eu.vendeli.rethis.types.core/PoolConfiguration.poolSize|{}poolSize[0]
-        final fun <get-poolSize>(): kotlin/Int // eu.vendeli.rethis.types.core/PoolConfiguration.poolSize.<get-poolSize>|<get-poolSize>(){}[0]
-        final fun <set-poolSize>(kotlin/Int) // eu.vendeli.rethis.types.core/PoolConfiguration.poolSize.<set-poolSize>|<set-poolSize>(kotlin.Int){}[0]
-
-    final fun component1(): kotlin/Int // eu.vendeli.rethis.types.core/PoolConfiguration.component1|component1(){}[0]
-    final fun component2(): kotlinx.coroutines/CoroutineDispatcher // eu.vendeli.rethis.types.core/PoolConfiguration.component2|component2(){}[0]
-    final fun copy(kotlin/Int = ..., kotlinx.coroutines/CoroutineDispatcher = ...): eu.vendeli.rethis.types.core/PoolConfiguration // eu.vendeli.rethis.types.core/PoolConfiguration.copy|copy(kotlin.Int;kotlinx.coroutines.CoroutineDispatcher){}[0]
-    final fun equals(kotlin/Any?): kotlin/Boolean // eu.vendeli.rethis.types.core/PoolConfiguration.equals|equals(kotlin.Any?){}[0]
-    final fun hashCode(): kotlin/Int // eu.vendeli.rethis.types.core/PoolConfiguration.hashCode|hashCode(){}[0]
-    final fun toString(): kotlin/String // eu.vendeli.rethis.types.core/PoolConfiguration.toString|toString(){}[0]
 }
 
 final class eu.vendeli.rethis.types.core/Push : eu.vendeli.rethis.types.core/RType { // eu.vendeli.rethis.types.core/Push|null[0]
@@ -849,7 +864,7 @@ final class eu.vendeli.rethis/ReThis { // eu.vendeli.rethis/ReThis|null[0]
     final fun reconnect() // eu.vendeli.rethis/ReThis.reconnect|reconnect(){}[0]
     final suspend fun execute(kotlin.collections/List<eu.vendeli.rethis.types.core/Argument>, kotlin/Boolean = ...): eu.vendeli.rethis.types.core/RType // eu.vendeli.rethis/ReThis.execute|execute(kotlin.collections.List<eu.vendeli.rethis.types.core.Argument>;kotlin.Boolean){}[0]
     final suspend fun pipeline(kotlin.coroutines/SuspendFunction1<eu.vendeli.rethis/ReThis, kotlin/Unit>): kotlin.collections/List<eu.vendeli.rethis.types.core/RType> // eu.vendeli.rethis/ReThis.pipeline|pipeline(kotlin.coroutines.SuspendFunction1<eu.vendeli.rethis.ReThis,kotlin.Unit>){}[0]
-    final suspend fun transaction(kotlin.coroutines/SuspendFunction1<eu.vendeli.rethis/ReThis, kotlin/Unit>): kotlin.collections/List<eu.vendeli.rethis.types.core/RType> // eu.vendeli.rethis/ReThis.transaction|transaction(kotlin.coroutines.SuspendFunction1<eu.vendeli.rethis.ReThis,kotlin.Unit>){}[0]
+    final suspend fun transaction(eu.vendeli.rethis.types.core/ConnectionSource = ..., kotlin.coroutines/SuspendFunction1<eu.vendeli.rethis/ReThis, kotlin/Unit>): kotlin.collections/List<eu.vendeli.rethis.types.core/RType> // eu.vendeli.rethis/ReThis.transaction|transaction(eu.vendeli.rethis.types.core.ConnectionSource;kotlin.coroutines.SuspendFunction1<eu.vendeli.rethis.ReThis,kotlin.Unit>){}[0]
 }
 
 final class eu.vendeli.rethis/ReThisException : kotlin/RuntimeException { // eu.vendeli.rethis/ReThisException|null[0]
@@ -1631,6 +1646,7 @@ final object eu.vendeli.rethis.types.options/WITHMATCHLEN : eu.vendeli.rethis.ty
     final fun toString(): kotlin/String // eu.vendeli.rethis.types.options/WITHMATCHLEN.toString|toString(){}[0]
 }
 
+final fun (eu.vendeli.rethis.types.core/RType).eu.vendeli.rethis.utils/isOk(): kotlin/Boolean // eu.vendeli.rethis.utils/isOk|isOk@eu.vendeli.rethis.types.core.RType(){}[0]
 final fun (eu.vendeli.rethis/ReThis).eu.vendeli.rethis.wrappers/Hash(kotlin/String): eu.vendeli.rethis.wrappers/ReThisMap // eu.vendeli.rethis.wrappers/Hash|Hash@eu.vendeli.rethis.ReThis(kotlin.String){}[0]
 final fun (eu.vendeli.rethis/ReThis).eu.vendeli.rethis.wrappers/Set(kotlin/String): eu.vendeli.rethis.wrappers/ReThisSet // eu.vendeli.rethis.wrappers/Set|Set@eu.vendeli.rethis.ReThis(kotlin.String){}[0]
 final fun (kotlin/Any).eu.vendeli.rethis.types.core/toArg(): eu.vendeli.rethis.types.core/Argument // eu.vendeli.rethis.types.core/toArg|toArg@kotlin.Any(){}[0]

--- a/api/re.this.klib.api
+++ b/api/re.this.klib.api
@@ -513,7 +513,7 @@ final class eu.vendeli.rethis.types.core/BulkString : eu.vendeli.rethis.types.co
 }
 
 final class eu.vendeli.rethis.types.core/ClientConfiguration { // eu.vendeli.rethis.types.core/ClientConfiguration|null[0]
-    constructor <init>(kotlin/Int? = ..., io.ktor.utils.io.charsets/Charset = ..., io.ktor.network.tls/TLSConfig? = ..., eu.vendeli.rethis.types.core/AuthConfiguration? = ..., eu.vendeli.rethis.types.core/ConnectionConfiguration = ..., eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration = ..., eu.vendeli.rethis.types.core/SocketConfiguration = ...) // eu.vendeli.rethis.types.core/ClientConfiguration.<init>|<init>(kotlin.Int?;io.ktor.utils.io.charsets.Charset;io.ktor.network.tls.TLSConfig?;eu.vendeli.rethis.types.core.AuthConfiguration?;eu.vendeli.rethis.types.core.ConnectionConfiguration;eu.vendeli.rethis.types.core.ReconnectionStrategyConfiguration;eu.vendeli.rethis.types.core.SocketConfiguration){}[0]
+    constructor <init>(kotlin/Int? = ..., io.ktor.utils.io.charsets/Charset = ..., io.ktor.network.tls/TLSConfig? = ..., eu.vendeli.rethis.types.core/AuthConfiguration? = ..., eu.vendeli.rethis.types.core/ConnectionConfiguration = ..., eu.vendeli.rethis.types.core/SocketConfiguration = ...) // eu.vendeli.rethis.types.core/ClientConfiguration.<init>|<init>(kotlin.Int?;io.ktor.utils.io.charsets.Charset;io.ktor.network.tls.TLSConfig?;eu.vendeli.rethis.types.core.AuthConfiguration?;eu.vendeli.rethis.types.core.ConnectionConfiguration;eu.vendeli.rethis.types.core.SocketConfiguration){}[0]
 
     final var charset // eu.vendeli.rethis.types.core/ClientConfiguration.charset|{}charset[0]
         final fun <get-charset>(): io.ktor.utils.io.charsets/Charset // eu.vendeli.rethis.types.core/ClientConfiguration.charset.<get-charset>|<get-charset>(){}[0]
@@ -530,16 +530,15 @@ final class eu.vendeli.rethis.types.core/ClientConfiguration { // eu.vendeli.ret
     final fun component2(): io.ktor.utils.io.charsets/Charset // eu.vendeli.rethis.types.core/ClientConfiguration.component2|component2(){}[0]
     final fun component3(): io.ktor.network.tls/TLSConfig? // eu.vendeli.rethis.types.core/ClientConfiguration.component3|component3(){}[0]
     final fun connection(kotlin/Function1<eu.vendeli.rethis.types.core/ConnectionConfiguration, kotlin/Unit>) // eu.vendeli.rethis.types.core/ClientConfiguration.connection|connection(kotlin.Function1<eu.vendeli.rethis.types.core.ConnectionConfiguration,kotlin.Unit>){}[0]
-    final fun copy(kotlin/Int? = ..., io.ktor.utils.io.charsets/Charset = ..., io.ktor.network.tls/TLSConfig? = ..., eu.vendeli.rethis.types.core/AuthConfiguration? = ..., eu.vendeli.rethis.types.core/ConnectionConfiguration = ..., eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration = ..., eu.vendeli.rethis.types.core/SocketConfiguration = ...): eu.vendeli.rethis.types.core/ClientConfiguration // eu.vendeli.rethis.types.core/ClientConfiguration.copy|copy(kotlin.Int?;io.ktor.utils.io.charsets.Charset;io.ktor.network.tls.TLSConfig?;eu.vendeli.rethis.types.core.AuthConfiguration?;eu.vendeli.rethis.types.core.ConnectionConfiguration;eu.vendeli.rethis.types.core.ReconnectionStrategyConfiguration;eu.vendeli.rethis.types.core.SocketConfiguration){}[0]
+    final fun copy(kotlin/Int? = ..., io.ktor.utils.io.charsets/Charset = ..., io.ktor.network.tls/TLSConfig? = ..., eu.vendeli.rethis.types.core/AuthConfiguration? = ..., eu.vendeli.rethis.types.core/ConnectionConfiguration = ..., eu.vendeli.rethis.types.core/SocketConfiguration = ...): eu.vendeli.rethis.types.core/ClientConfiguration // eu.vendeli.rethis.types.core/ClientConfiguration.copy|copy(kotlin.Int?;io.ktor.utils.io.charsets.Charset;io.ktor.network.tls.TLSConfig?;eu.vendeli.rethis.types.core.AuthConfiguration?;eu.vendeli.rethis.types.core.ConnectionConfiguration;eu.vendeli.rethis.types.core.SocketConfiguration){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // eu.vendeli.rethis.types.core/ClientConfiguration.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // eu.vendeli.rethis.types.core/ClientConfiguration.hashCode|hashCode(){}[0]
-    final fun reconnectionStrategy(kotlin/Function1<eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration, kotlin/Unit>) // eu.vendeli.rethis.types.core/ClientConfiguration.reconnectionStrategy|reconnectionStrategy(kotlin.Function1<eu.vendeli.rethis.types.core.ReconnectionStrategyConfiguration,kotlin.Unit>){}[0]
     final fun socket(kotlin/Function1<eu.vendeli.rethis.types.core/SocketConfiguration, kotlin/Unit>) // eu.vendeli.rethis.types.core/ClientConfiguration.socket|socket(kotlin.Function1<eu.vendeli.rethis.types.core.SocketConfiguration,kotlin.Unit>){}[0]
     final fun toString(): kotlin/String // eu.vendeli.rethis.types.core/ClientConfiguration.toString|toString(){}[0]
 }
 
 final class eu.vendeli.rethis.types.core/ConnectionConfiguration { // eu.vendeli.rethis.types.core/ConnectionConfiguration|null[0]
-    constructor <init>(eu.vendeli.rethis.types.core/ConnectionSource = ..., kotlin/Int = ..., kotlinx.coroutines/CoroutineDispatcher = ...) // eu.vendeli.rethis.types.core/ConnectionConfiguration.<init>|<init>(eu.vendeli.rethis.types.core.ConnectionSource;kotlin.Int;kotlinx.coroutines.CoroutineDispatcher){}[0]
+    constructor <init>(eu.vendeli.rethis.types.core/ConnectionSource = ..., kotlin/Int = ..., kotlinx.coroutines/CoroutineDispatcher = ..., kotlin/Int = ..., kotlin/Long = ...) // eu.vendeli.rethis.types.core/ConnectionConfiguration.<init>|<init>(eu.vendeli.rethis.types.core.ConnectionSource;kotlin.Int;kotlinx.coroutines.CoroutineDispatcher;kotlin.Int;kotlin.Long){}[0]
 
     final var defaultConnectionSource // eu.vendeli.rethis.types.core/ConnectionConfiguration.defaultConnectionSource|{}defaultConnectionSource[0]
         final fun <get-defaultConnectionSource>(): eu.vendeli.rethis.types.core/ConnectionSource // eu.vendeli.rethis.types.core/ConnectionConfiguration.defaultConnectionSource.<get-defaultConnectionSource>|<get-defaultConnectionSource>(){}[0]
@@ -550,11 +549,19 @@ final class eu.vendeli.rethis.types.core/ConnectionConfiguration { // eu.vendeli
     final var poolSize // eu.vendeli.rethis.types.core/ConnectionConfiguration.poolSize|{}poolSize[0]
         final fun <get-poolSize>(): kotlin/Int // eu.vendeli.rethis.types.core/ConnectionConfiguration.poolSize.<get-poolSize>|<get-poolSize>(){}[0]
         final fun <set-poolSize>(kotlin/Int) // eu.vendeli.rethis.types.core/ConnectionConfiguration.poolSize.<set-poolSize>|<set-poolSize>(kotlin.Int){}[0]
+    final var reconnectAttempts // eu.vendeli.rethis.types.core/ConnectionConfiguration.reconnectAttempts|{}reconnectAttempts[0]
+        final fun <get-reconnectAttempts>(): kotlin/Int // eu.vendeli.rethis.types.core/ConnectionConfiguration.reconnectAttempts.<get-reconnectAttempts>|<get-reconnectAttempts>(){}[0]
+        final fun <set-reconnectAttempts>(kotlin/Int) // eu.vendeli.rethis.types.core/ConnectionConfiguration.reconnectAttempts.<set-reconnectAttempts>|<set-reconnectAttempts>(kotlin.Int){}[0]
+    final var reconnectDelay // eu.vendeli.rethis.types.core/ConnectionConfiguration.reconnectDelay|{}reconnectDelay[0]
+        final fun <get-reconnectDelay>(): kotlin/Long // eu.vendeli.rethis.types.core/ConnectionConfiguration.reconnectDelay.<get-reconnectDelay>|<get-reconnectDelay>(){}[0]
+        final fun <set-reconnectDelay>(kotlin/Long) // eu.vendeli.rethis.types.core/ConnectionConfiguration.reconnectDelay.<set-reconnectDelay>|<set-reconnectDelay>(kotlin.Long){}[0]
 
     final fun component1(): eu.vendeli.rethis.types.core/ConnectionSource // eu.vendeli.rethis.types.core/ConnectionConfiguration.component1|component1(){}[0]
     final fun component2(): kotlin/Int // eu.vendeli.rethis.types.core/ConnectionConfiguration.component2|component2(){}[0]
     final fun component3(): kotlinx.coroutines/CoroutineDispatcher // eu.vendeli.rethis.types.core/ConnectionConfiguration.component3|component3(){}[0]
-    final fun copy(eu.vendeli.rethis.types.core/ConnectionSource = ..., kotlin/Int = ..., kotlinx.coroutines/CoroutineDispatcher = ...): eu.vendeli.rethis.types.core/ConnectionConfiguration // eu.vendeli.rethis.types.core/ConnectionConfiguration.copy|copy(eu.vendeli.rethis.types.core.ConnectionSource;kotlin.Int;kotlinx.coroutines.CoroutineDispatcher){}[0]
+    final fun component4(): kotlin/Int // eu.vendeli.rethis.types.core/ConnectionConfiguration.component4|component4(){}[0]
+    final fun component5(): kotlin/Long // eu.vendeli.rethis.types.core/ConnectionConfiguration.component5|component5(){}[0]
+    final fun copy(eu.vendeli.rethis.types.core/ConnectionSource = ..., kotlin/Int = ..., kotlinx.coroutines/CoroutineDispatcher = ..., kotlin/Int = ..., kotlin/Long = ...): eu.vendeli.rethis.types.core/ConnectionConfiguration // eu.vendeli.rethis.types.core/ConnectionConfiguration.copy|copy(eu.vendeli.rethis.types.core.ConnectionSource;kotlin.Int;kotlinx.coroutines.CoroutineDispatcher;kotlin.Int;kotlin.Long){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // eu.vendeli.rethis.types.core/ConnectionConfiguration.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // eu.vendeli.rethis.types.core/ConnectionConfiguration.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // eu.vendeli.rethis.types.core/ConnectionConfiguration.toString|toString(){}[0]
@@ -653,28 +660,6 @@ final class eu.vendeli.rethis.types.core/RSet : eu.vendeli.rethis.types.core/RTy
     final fun equals(kotlin/Any?): kotlin/Boolean // eu.vendeli.rethis.types.core/RSet.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // eu.vendeli.rethis.types.core/RSet.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // eu.vendeli.rethis.types.core/RSet.toString|toString(){}[0]
-}
-
-final class eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration { // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration|null[0]
-    constructor <init>(kotlin/Boolean = ..., kotlin/Int = ..., kotlin/Long = ...) // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.<init>|<init>(kotlin.Boolean;kotlin.Int;kotlin.Long){}[0]
-
-    final var doHealthCheck // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.doHealthCheck|{}doHealthCheck[0]
-        final fun <get-doHealthCheck>(): kotlin/Boolean // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.doHealthCheck.<get-doHealthCheck>|<get-doHealthCheck>(){}[0]
-        final fun <set-doHealthCheck>(kotlin/Boolean) // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.doHealthCheck.<set-doHealthCheck>|<set-doHealthCheck>(kotlin.Boolean){}[0]
-    final var reconnectAttempts // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.reconnectAttempts|{}reconnectAttempts[0]
-        final fun <get-reconnectAttempts>(): kotlin/Int // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.reconnectAttempts.<get-reconnectAttempts>|<get-reconnectAttempts>(){}[0]
-        final fun <set-reconnectAttempts>(kotlin/Int) // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.reconnectAttempts.<set-reconnectAttempts>|<set-reconnectAttempts>(kotlin.Int){}[0]
-    final var reconnectDelay // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.reconnectDelay|{}reconnectDelay[0]
-        final fun <get-reconnectDelay>(): kotlin/Long // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.reconnectDelay.<get-reconnectDelay>|<get-reconnectDelay>(){}[0]
-        final fun <set-reconnectDelay>(kotlin/Long) // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.reconnectDelay.<set-reconnectDelay>|<set-reconnectDelay>(kotlin.Long){}[0]
-
-    final fun component1(): kotlin/Boolean // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.component1|component1(){}[0]
-    final fun component2(): kotlin/Int // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.component2|component2(){}[0]
-    final fun component3(): kotlin/Long // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.component3|component3(){}[0]
-    final fun copy(kotlin/Boolean = ..., kotlin/Int = ..., kotlin/Long = ...): eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.copy|copy(kotlin.Boolean;kotlin.Int;kotlin.Long){}[0]
-    final fun equals(kotlin/Any?): kotlin/Boolean // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.equals|equals(kotlin.Any?){}[0]
-    final fun hashCode(): kotlin/Int // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.hashCode|hashCode(){}[0]
-    final fun toString(): kotlin/String // eu.vendeli.rethis.types.core/ReconnectionStrategyConfiguration.toString|toString(){}[0]
 }
 
 final class eu.vendeli.rethis.types.core/SocketConfiguration { // eu.vendeli.rethis.types.core/SocketConfiguration|null[0]
@@ -862,6 +847,7 @@ final class eu.vendeli.rethis/ReThis { // eu.vendeli.rethis/ReThis|null[0]
 
     final fun disconnect() // eu.vendeli.rethis/ReThis.disconnect|disconnect(){}[0]
     final fun reconnect() // eu.vendeli.rethis/ReThis.reconnect|reconnect(){}[0]
+    final fun shutdown() // eu.vendeli.rethis/ReThis.shutdown|shutdown(){}[0]
     final suspend fun execute(kotlin.collections/List<eu.vendeli.rethis.types.core/Argument>, kotlin/Boolean = ...): eu.vendeli.rethis.types.core/RType // eu.vendeli.rethis/ReThis.execute|execute(kotlin.collections.List<eu.vendeli.rethis.types.core.Argument>;kotlin.Boolean){}[0]
     final suspend fun pipeline(kotlin.coroutines/SuspendFunction1<eu.vendeli.rethis/ReThis, kotlin/Unit>): kotlin.collections/List<eu.vendeli.rethis.types.core/RType> // eu.vendeli.rethis/ReThis.pipeline|pipeline(kotlin.coroutines.SuspendFunction1<eu.vendeli.rethis.ReThis,kotlin.Unit>){}[0]
     final suspend fun transaction(eu.vendeli.rethis.types.core/ConnectionSource = ..., kotlin.coroutines/SuspendFunction1<eu.vendeli.rethis/ReThis, kotlin/Unit>): kotlin.collections/List<eu.vendeli.rethis.types.core/RType> // eu.vendeli.rethis/ReThis.transaction|transaction(eu.vendeli.rethis.types.core.ConnectionSource;kotlin.coroutines.SuspendFunction1<eu.vendeli.rethis.ReThis,kotlin.Unit>){}[0]

--- a/api/rethis.api
+++ b/api/rethis.api
@@ -11,7 +11,7 @@ public final class eu/vendeli/rethis/ReThis {
 	public final fun getSubscriptions ()Leu/vendeli/rethis/types/core/ActiveSubscriptions;
 	public final fun isDisconnected ()Z
 	public final fun pipeline (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun reconnect ()V
+	public final fun reconnect ()Lkotlinx/coroutines/Job;
 	public final fun shutdown ()V
 	public final fun transaction (Leu/vendeli/rethis/types/core/ConnectionSource;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun transaction$default (Leu/vendeli/rethis/ReThis;Leu/vendeli/rethis/types/core/ConnectionSource;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -868,7 +868,7 @@ public final class eu/vendeli/rethis/types/core/F64 : eu/vendeli/rethis/types/co
 
 public final class eu/vendeli/rethis/types/core/Host : eu/vendeli/rethis/types/core/Address {
 	public fun <init> (Ljava/lang/String;I)V
-	public synthetic fun getSocket$re_this ()Lio/ktor/network/sockets/SocketAddress;
+	public synthetic fun getSocket$rethis ()Lio/ktor/network/sockets/SocketAddress;
 }
 
 public final class eu/vendeli/rethis/types/core/Int64 : eu/vendeli/rethis/types/core/RPrimitive {
@@ -1078,12 +1078,12 @@ public abstract interface class eu/vendeli/rethis/types/core/SubscriptionHandler
 
 public final class eu/vendeli/rethis/types/core/UnixSocket : eu/vendeli/rethis/types/core/Address {
 	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun getSocket$re_this ()Lio/ktor/network/sockets/SocketAddress;
+	public synthetic fun getSocket$rethis ()Lio/ktor/network/sockets/SocketAddress;
 }
 
 public final class eu/vendeli/rethis/types/core/Url : eu/vendeli/rethis/types/core/Address {
 	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun getSocket$re_this ()Lio/ktor/network/sockets/SocketAddress;
+	public synthetic fun getSocket$rethis ()Lio/ktor/network/sockets/SocketAddress;
 }
 
 public abstract interface class eu/vendeli/rethis/types/core/VaryingArgument {

--- a/api/rethis.klib.api
+++ b/api/rethis.klib.api
@@ -5,7 +5,7 @@
 // - Show manifest properties: true
 // - Show declarations: true
 
-// Library unique name: <eu.vendeli.re.this:re.this>
+// Library unique name: <eu.vendeli.rethis:rethis>
 open annotation class eu.vendeli.rethis.annotations/ConfigurationDSL : kotlin/Annotation { // eu.vendeli.rethis.annotations/ConfigurationDSL|null[0]
     constructor <init>() // eu.vendeli.rethis.annotations/ConfigurationDSL.<init>|<init>(){}[0]
 }
@@ -868,7 +868,7 @@ final class eu.vendeli.rethis/ReThis { // eu.vendeli.rethis/ReThis|null[0]
         final fun <get-subscriptions>(): eu.vendeli.rethis.types.core/ActiveSubscriptions // eu.vendeli.rethis/ReThis.subscriptions.<get-subscriptions>|<get-subscriptions>(){}[0]
 
     final fun disconnect() // eu.vendeli.rethis/ReThis.disconnect|disconnect(){}[0]
-    final fun reconnect() // eu.vendeli.rethis/ReThis.reconnect|reconnect(){}[0]
+    final fun reconnect(): kotlinx.coroutines/Job // eu.vendeli.rethis/ReThis.reconnect|reconnect(){}[0]
     final fun shutdown() // eu.vendeli.rethis/ReThis.shutdown|shutdown(){}[0]
     final suspend fun execute(kotlin.collections/List<eu.vendeli.rethis.types.core/Argument>, kotlin/Boolean = ...): eu.vendeli.rethis.types.core/RType // eu.vendeli.rethis/ReThis.execute|execute(kotlin.collections.List<eu.vendeli.rethis.types.core.Argument>;kotlin.Boolean){}[0]
     final suspend fun pipeline(kotlin.coroutines/SuspendFunction1<eu.vendeli.rethis/ReThis, kotlin/Unit>): kotlin.collections/List<eu.vendeli.rethis.types.core/RType> // eu.vendeli.rethis/ReThis.pipeline|pipeline(kotlin.coroutines.SuspendFunction1<eu.vendeli.rethis.ReThis,kotlin.Unit>){}[0]

--- a/benchmarks/src/main/kotlin/eu/vendeli/rethis/benchmarks/JedisBenchmark.kt
+++ b/benchmarks/src/main/kotlin/eu/vendeli/rethis/benchmarks/JedisBenchmark.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
 @Warmup(iterations = 2, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Timeout(time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(1, jvmArgsAppend = ["-Xms500m", "-Xmx12g", "-Xss2m", "-XX:MaxMetaspaceSize=1g"])
+@Fork(1, jvmArgsAppend = ["-Xms12g", "-Xmx12g", "-Xss2m", "-XX:MaxMetaspaceSize=1g"])
 class JedisBenchmark {
     private lateinit var jedis: JedisPooled
 

--- a/benchmarks/src/main/kotlin/eu/vendeli/rethis/benchmarks/KredsBenchmark.kt
+++ b/benchmarks/src/main/kotlin/eu/vendeli/rethis/benchmarks/KredsBenchmark.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit
 @Warmup(iterations = 2, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Timeout(time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(1, jvmArgsAppend = ["-Xms500m", "-Xmx12g", "-Xss2m", "-XX:MaxMetaspaceSize=1g"])
+@Fork(1, jvmArgsAppend = ["-Xms12g", "-Xmx12g", "-Xss2m", "-XX:MaxMetaspaceSize=1g"])
 class KredsBenchmark {
     private lateinit var kreds: KredsClient
 

--- a/benchmarks/src/main/kotlin/eu/vendeli/rethis/benchmarks/LettuceBenchmark.kt
+++ b/benchmarks/src/main/kotlin/eu/vendeli/rethis/benchmarks/LettuceBenchmark.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit
 @Warmup(iterations = 2, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Timeout(time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(1, jvmArgsAppend = ["-Xms500m", "-Xmx12g", "-Xss2m", "-XX:MaxMetaspaceSize=1g"])
+@Fork(1, jvmArgsAppend = ["-Xms12g", "-Xmx12g", "-Xss2m", "-XX:MaxMetaspaceSize=1g"])
 class LettuceBenchmark {
     private lateinit var lettuce: RedisAsyncCommands<String, String>
 

--- a/benchmarks/src/main/kotlin/eu/vendeli/rethis/benchmarks/RethisBenchmark.kt
+++ b/benchmarks/src/main/kotlin/eu/vendeli/rethis/benchmarks/RethisBenchmark.kt
@@ -29,7 +29,7 @@ class RethisBenchmark {
 
     @TearDown
     fun tearDown() {
-        rethis.disconnect()
+        rethis.shutdown()
     }
 
     @Benchmark

--- a/benchmarks/src/main/kotlin/eu/vendeli/rethis/benchmarks/RethisBenchmark.kt
+++ b/benchmarks/src/main/kotlin/eu/vendeli/rethis/benchmarks/RethisBenchmark.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit
 @Warmup(iterations = 2, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Timeout(time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(1, jvmArgsAppend = ["-Xms500m", "-Xmx12g", "-Xss2m", "-XX:MaxMetaspaceSize=1g"])
+@Fork(1, jvmArgsAppend = ["-Xms12g", "-Xmx12g", "-Xss2m", "-XX:MaxMetaspaceSize=1g"])
 class RethisBenchmark {
     private lateinit var rethis: ReThis
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     publish
 }
 
-group = "eu.vendeli.re.this"
+group = "eu.vendeli.rethis"
 version = System.getenv("libVersion") ?: "dev"
 
 repositories { mavenCentral() }

--- a/buildSrc/src/main/kotlin/publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish.gradle.kts
@@ -25,6 +25,7 @@ mavenPublishing {
 
     pom {
         name = project.name
+        group = project.group
         description = "Kotlin Multiplatform Redis Client: coroutine-based, DSL-powered, and easy to use."
         inceptionYear = "2024"
         url = REPO_URL

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "re.this"
+rootProject.name = "rethis"
 
 include("benchmarks")
 

--- a/src/commonMain/kotlin/eu/vendeli/rethis/ReThis.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/ReThis.kt
@@ -65,6 +65,10 @@ class ReThis(
         if (connectionPool.isEmpty) connectionPool.prepare()
     }
 
+    fun shutdown() = runBlocking {
+        rootJob.cancelAndJoin()
+    }
+
     suspend fun pipeline(block: suspend ReThis.() -> Unit): List<RType> {
         val responses = mutableListOf<RType>()
         val pipelineCtx = takeFromCoCtx(CoPipelineCtx)

--- a/src/commonMain/kotlin/eu/vendeli/rethis/ReThis.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/ReThis.kt
@@ -127,7 +127,8 @@ class ReThis(
 
         return try {
             logger.debug("Started transaction")
-            val transactionResponse = conn.sendRequest(listOf("MULTI".toArg()))
+            val transactionResponse = conn
+                .sendRequest(listOf("MULTI".toArg()))
                 .parseResponse()
                 .readResponseWrapped(cfg.charset)
             if (!transactionResponse.isOk()) exception {
@@ -140,7 +141,8 @@ class ReThis(
                     runCatching { block() }.getOrElse { e = it }
                 }.join()
             e?.also {
-                val discardResponse = conn.sendRequest(listOf("DISCARD".toArg()))
+                val discardResponse = conn
+                    .sendRequest(listOf("DISCARD".toArg()))
                     .parseResponse()
                     .readResponseWrapped(cfg.charset)
                 if (!discardResponse.isOk()) exception {
@@ -152,10 +154,12 @@ class ReThis(
 
             logger.debug("Transaction completed")
 
-            conn.sendRequest(listOf("EXEC".toArg()))
+            conn
+                .sendRequest(listOf("EXEC".toArg()))
                 .parseResponse()
                 .readResponseWrapped(cfg.charset)
-                .unwrapList<RType>().also {
+                .unwrapList<RType>()
+                .also {
                     logger.debug("Response payload: $it")
                 }
         } finally {

--- a/src/commonMain/kotlin/eu/vendeli/rethis/ReThis.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/ReThis.kt
@@ -109,7 +109,7 @@ class ReThis(
             return emptyList()
         }
         logger.info("Pipeline finished")
-        logger.trace("Such responses returned $responses")
+        logger.trace { "Such responses returned $responses" }
         return responses
     }
 
@@ -231,7 +231,7 @@ class ReThis(
     }
 
     private suspend fun Connection.sendRequest(payload: List<Argument>): Connection = apply {
-        logger.trace("Sending request with such payload $payload")
+        logger.trace { "Sending request with such payload $payload" }
         output.writeBuffer(bufferValues(payload, cfg.charset))
         output.flush()
     }

--- a/src/commonMain/kotlin/eu/vendeli/rethis/ReThis.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/ReThis.kt
@@ -94,16 +94,12 @@ class ReThis(
             val connection = ctxConn
             if (connection != null) {
                 connection.sendRequest(pipelinedPayload)
-                requests.map {
-                    connection.parseResponse()
-                }.map {
-                    it.readResponseWrapped(cfg.charset)
+                requests.forEach { _ -> responses.add(connection.readResponseWrapped(cfg.charset)) }
+            } else {
+                connectionPool.use { connection ->
+                    connection.sendRequest(pipelinedPayload)
+                    requests.forEach { _ -> responses.add(connection.readResponseWrapped(cfg.charset)) }
                 }
-            } else connectionPool.use { connection ->
-                connection.sendRequest(pipelinedPayload)
-                requests.map { connection.parseResponse() }
-            }.map {
-                it.readResponseWrapped(cfg.charset)
             }
             requests.clear()
         } else {

--- a/src/commonMain/kotlin/eu/vendeli/rethis/ReThis.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/ReThis.kt
@@ -60,9 +60,7 @@ class ReThis(
     val isDisconnected: Boolean get() = connectionPool.isEmpty
 
     fun disconnect() = connectionPool.disconnect()
-    fun reconnect() {
-        if (connectionPool.isEmpty) connectionPool.prepare()
-    }
+    fun reconnect() = connectionPool.prepare()
 
     fun shutdown() = runBlocking {
         rootJob.cancelAndJoin()

--- a/src/commonMain/kotlin/eu/vendeli/rethis/commands/PubSubCommands.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/commands/PubSubCommands.kt
@@ -1,6 +1,7 @@
 package eu.vendeli.rethis.commands
 
 import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.exception
 import eu.vendeli.rethis.types.common.ChannelSubscription
 import eu.vendeli.rethis.types.common.PubSubNumEntry
 import eu.vendeli.rethis.types.core.*
@@ -83,7 +84,7 @@ suspend fun ReThis.pubSubShardNumSub(vararg channel: String): List<PubSubNumEntr
 }
 
 suspend fun ReThis.pUnsubscribe(vararg pattern: String): RType {
-    require(pattern.isNotEmpty())
+    if (pattern.isEmpty()) exception { "At least one pattern is required" }
     pattern.forEach { subscriptions.unsubscribe(it) }
     return execute(
         listOf(
@@ -136,7 +137,7 @@ suspend fun ReThis.subscribe(
 }
 
 suspend fun ReThis.sUnsubscribe(vararg pattern: String): RType {
-    require(pattern.isNotEmpty())
+    if (pattern.isEmpty()) exception { "At least one pattern is required" }
     pattern.forEach { subscriptions.unsubscribe(it) }
     return execute(
         listOf(
@@ -147,7 +148,7 @@ suspend fun ReThis.sUnsubscribe(vararg pattern: String): RType {
 }
 
 suspend fun ReThis.unsubscribe(vararg pattern: String): RType {
-    require(pattern.isNotEmpty())
+    if (pattern.isEmpty()) exception { "At least one pattern is required" }
     pattern.forEach { subscriptions.unsubscribe(it) }
     return execute(
         listOf(

--- a/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ClientConfiguration.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ClientConfiguration.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.IO
  * @property charset The character set to use for communication.
  * @property tlsConfig The TLS configuration to use when connecting.
  * @property auth The authentication options.
- * @property poolConfiguration The pool configuration.
+ * @property connectionConfiguration The pool configuration.
  * @property reconnectionStrategy The reconnection strategy to use.
  */
 @ConfigurationDSL
@@ -23,7 +23,7 @@ data class ClientConfiguration(
     var charset: Charset = Charsets.UTF_8,
     var tlsConfig: TLSConfig? = null,
     internal var auth: AuthConfiguration? = null,
-    internal val poolConfiguration: PoolConfiguration = PoolConfiguration(),
+    internal val connectionConfiguration: ConnectionConfiguration = ConnectionConfiguration(),
     internal val reconnectionStrategy: ReconnectionStrategyConfiguration = ReconnectionStrategyConfiguration(),
     internal val socketConfiguration: SocketConfiguration = SocketConfiguration(),
 ) {
@@ -42,8 +42,8 @@ data class ClientConfiguration(
      *
      * @param block A lambda to configure the pool settings.
      */
-    fun pool(block: PoolConfiguration.() -> Unit) {
-        poolConfiguration.block()
+    fun connection(block: ConnectionConfiguration.() -> Unit) {
+        connectionConfiguration.block()
     }
 
     /**
@@ -109,13 +109,15 @@ data class ReconnectionStrategyConfiguration(
 )
 
 /**
- * Configuration for redis connection pool.
+ * Configuration for redis connection.
  *
+ * @property defaultConnectionSource the default connection source, defaults to [ConnectionSource.POOL]
  * @property poolSize the size of the connection pool, defaults to 50
  * @property dispatcher the dispatcher to use for connection pool coroutines, defaults to [Dispatchers.IO]
  */
 @ConfigurationDSL
-data class PoolConfiguration(
+data class ConnectionConfiguration(
+    var defaultConnectionSource: ConnectionSource = ConnectionSource.POOL,
     var poolSize: Int = 50,
     var dispatcher: CoroutineDispatcher = Dispatchers.IO,
 )

--- a/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ClientConfiguration.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ClientConfiguration.kt
@@ -24,7 +24,6 @@ data class ClientConfiguration(
     var tlsConfig: TLSConfig? = null,
     internal var auth: AuthConfiguration? = null,
     internal val connectionConfiguration: ConnectionConfiguration = ConnectionConfiguration(),
-    internal val reconnectionStrategy: ReconnectionStrategyConfiguration = ReconnectionStrategyConfiguration(),
     internal val socketConfiguration: SocketConfiguration = SocketConfiguration(),
 ) {
     /**
@@ -44,15 +43,6 @@ data class ClientConfiguration(
      */
     fun connection(block: ConnectionConfiguration.() -> Unit) {
         connectionConfiguration.block()
-    }
-
-    /**
-     * Configures the reconnection strategy.
-     *
-     * @param block A lambda to configure the reconnection strategy.
-     */
-    fun reconnectionStrategy(block: ReconnectionStrategyConfiguration.() -> Unit) {
-        reconnectionStrategy.block()
     }
 
     /**
@@ -95,29 +85,19 @@ data class SocketConfiguration(
 )
 
 /**
- * Configuration for redis connection reconnection strategy.
- *
- * @property doHealthCheck if true, performs health checks on the connection before adding it to the pool, defaults to true
- * @property reconnectAttempts the number of times to attempt reconnecting to the redis server on failure, defaults to 3
- * @property reconnectDelay the delay in milliseconds between reconnecting, defaults to 3000L
- */
-@ConfigurationDSL
-data class ReconnectionStrategyConfiguration(
-    var doHealthCheck: Boolean = true,
-    var reconnectAttempts: Int = 3,
-    var reconnectDelay: Long = 3000L,
-)
-
-/**
  * Configuration for redis connection.
  *
  * @property defaultConnectionSource the default connection source, defaults to [ConnectionSource.POOL]
  * @property poolSize the size of the connection pool, defaults to 50
  * @property dispatcher the dispatcher to use for connection pool coroutines, defaults to [Dispatchers.IO]
+ * @property reconnectAttempts the number of times to attempt reconnecting to the redis server on failure, defaults to 3
+ * @property reconnectDelay the delay in milliseconds between reconnecting, defaults to 3000L
  */
 @ConfigurationDSL
 data class ConnectionConfiguration(
     var defaultConnectionSource: ConnectionSource = ConnectionSource.POOL,
     var poolSize: Int = 50,
     var dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    var reconnectAttempts: Int = 3,
+    var reconnectDelay: Long = 3000L,
 )

--- a/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ConnectionPool.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ConnectionPool.kt
@@ -131,7 +131,9 @@ internal class ConnectionPool(
             runCatching { createConn() }
                 .onSuccess { conn ->
                     launch {
-                        while (!trySend(conn).isSuccess) { yield() }
+                        while (!trySend(conn).isSuccess) {
+                            yield()
+                        }
                     }
                     logger.trace { "Connection refilled with $conn" }
                     return@launch

--- a/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ConnectionPool.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ConnectionPool.kt
@@ -96,7 +96,6 @@ internal class ConnectionPool(
         coldPool.send(connection)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
     private suspend fun cleaner() = withContext(Job(poolJob)) {
         while (isActive) {
             val connection = coldPool.receive()

--- a/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ConnectionPool.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ConnectionPool.kt
@@ -96,8 +96,7 @@ internal class ConnectionPool(
 
     private fun handle(connectionConfiguration: Connection) = poolScope.launch(Dispatchers.IO) {
         logger.trace("Releasing connection ${connectionConfiguration.socket}")
-        val cfg = client.cfg.reconnectionStrategy
-        if (cfg.doHealthCheck && connectionConfiguration.input.isClosedForRead) { // connection is corrupted
+        if (connectionConfiguration.input.isClosedForRead) { // connection is corrupted
             logger.warn("Connection ${connectionConfiguration.socket} is corrupted, refilling")
             launch {
                 connectionConfiguration.socket.close()
@@ -112,7 +111,7 @@ internal class ConnectionPool(
     }
 
     private suspend fun refill() {
-        val cfg = client.cfg.reconnectionStrategy
+        val cfg = client.cfg.connectionConfiguration
         if (cfg.reconnectAttempts <= 0) return
         var attempt = 0
         var ex: Throwable? = null

--- a/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ConnectionSource.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/types/core/ConnectionSource.kt
@@ -1,0 +1,12 @@
+package eu.vendeli.rethis.types.core
+
+/**
+ * Enum representing the source of a connection.
+ *
+ * @property POOL A connection from the connection pool.
+ * @property STANDALONE A standalone connection.
+ */
+enum class ConnectionSource {
+    POOL,
+    STANDALONE,
+}

--- a/src/commonMain/kotlin/eu/vendeli/rethis/types/core/RConnection.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/types/core/RConnection.kt
@@ -1,0 +1,14 @@
+package eu.vendeli.rethis.types.core
+
+import io.ktor.network.sockets.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.sync.Mutex
+
+data class RConnection(
+    val socket: Socket,
+    val input: ByteReadChannel,
+    val output: ByteWriteChannel,
+    val status: Mutex = Mutex(),
+)
+
+fun Socket.rConnection(): RConnection = RConnection(this, openReadChannel(), openWriteChannel())

--- a/src/commonMain/kotlin/eu/vendeli/rethis/types/core/RespCode.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/types/core/RespCode.kt
@@ -27,7 +27,9 @@ internal enum class RespCode(
     val isSimple = type == Type.SIMPLE || type == Type.SIMPLE_AGG
 
     enum class Type {
-        SIMPLE, SIMPLE_AGG, AGGREGATE
+        SIMPLE,
+        SIMPLE_AGG,
+        AGGREGATE,
     }
 
     companion object {

--- a/src/commonMain/kotlin/eu/vendeli/rethis/types/coroutine/CoLocalConn.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/types/coroutine/CoLocalConn.kt
@@ -1,11 +1,11 @@
 package eu.vendeli.rethis.types.coroutine
 
-import io.ktor.network.sockets.*
+import eu.vendeli.rethis.types.core.RConnection
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 
 class CoLocalConn(
-    val connection: Connection,
+    val connection: RConnection,
 ) : AbstractCoroutineContextElement(CoLocalConn),
     CoroutineContext.Element {
     override val key = Key

--- a/src/commonMain/kotlin/eu/vendeli/rethis/utils/CommonUtils.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/utils/CommonUtils.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KClass
 
+fun RType.isOk() = unwrap<String>() == "OK"
+
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
 internal inline fun <T> Any.cast(): T = this as T
 

--- a/src/commonMain/kotlin/eu/vendeli/rethis/utils/RequestUtils.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/utils/RequestUtils.kt
@@ -2,7 +2,6 @@ package eu.vendeli.rethis.utils
 
 import eu.vendeli.rethis.types.core.*
 import eu.vendeli.rethis.utils.Const.EOL
-import io.ktor.network.sockets.Connection
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.writeBuffer
@@ -19,7 +18,7 @@ internal inline fun Buffer.writeValues(value: List<Argument>, charset: Charset) 
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun bufferValues(value: List<Argument>, charset: Charset) = Buffer().writeValues(value, charset)
 
-internal suspend inline fun Connection.sendRequest(source: Source) {
+internal suspend inline fun RConnection.sendRequest(source: Source) {
     output.writeBuffer(source)
     output.flush()
 }

--- a/src/commonMain/kotlin/eu/vendeli/rethis/utils/ResponseUtils.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/utils/ResponseUtils.kt
@@ -11,7 +11,6 @@ import eu.vendeli.rethis.utils.Const.CARRIAGE_RETURN_BYTE
 import eu.vendeli.rethis.utils.Const.FALSE_BYTE
 import eu.vendeli.rethis.utils.Const.NEWLINE_BYTE
 import eu.vendeli.rethis.utils.Const.TRUE_BYTE
-import io.ktor.network.sockets.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
@@ -86,8 +85,8 @@ private suspend fun ByteReadChannel.processNestedAggregates(
     }
 }
 
-internal suspend inline fun Connection.parseResponse(): ArrayDeque<ResponseToken> = input.parseResponse()
-internal suspend inline fun Connection.readResponseWrapped(
+internal suspend inline fun RConnection.parseResponse(): ArrayDeque<ResponseToken> = input.parseResponse()
+internal suspend inline fun RConnection.readResponseWrapped(
     charset: Charset,
     rawOnly: Boolean = false,
 ) = parseResponse().readResponseWrapped(charset, rawOnly)

--- a/src/commonMain/kotlin/eu/vendeli/rethis/utils/ResponseUtils.kt
+++ b/src/commonMain/kotlin/eu/vendeli/rethis/utils/ResponseUtils.kt
@@ -129,7 +129,7 @@ private inline fun ArrayDeque<ResponseToken>.validatedResponseType(): Code {
 @Suppress("NOTHING_TO_INLINE")
 private inline fun ArrayDeque<ResponseToken>.validatedSimpleResponse(codeToken: Code): Source {
     if (!codeToken.code.isSimple) exception {
-        "Wrong response type, expected simple type, given ${codeToken.code}"
+        "Wrong response type, expected simple type, given ${codeToken.code}\nFull response: $this"
     }
 
     if (codeToken.code != RespCode.NULL && isEmpty()) exception {

--- a/src/jvmTest/kotlin/eu/vendeli/rethis/ReThisTestCtx.kt
+++ b/src/jvmTest/kotlin/eu/vendeli/rethis/ReThisTestCtx.kt
@@ -2,6 +2,7 @@ package eu.vendeli.rethis
 
 import com.redis.testcontainers.RedisContainer
 import io.kotest.core.spec.style.AnnotationSpec
+import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.testcontainers.utility.DockerImageName
@@ -25,5 +26,10 @@ abstract class ReThisTestCtx(
 
     protected fun resetClient(newClient: ReThis = ReThis(redis.host, redis.firstMappedPort)) {
         _client = newClient
+    }
+
+    @AfterAll
+    suspend fun afterAll() {
+        delay(1000)
     }
 }

--- a/src/jvmTest/kotlin/eu/vendeli/rethis/ReThisTestCtx.kt
+++ b/src/jvmTest/kotlin/eu/vendeli/rethis/ReThisTestCtx.kt
@@ -2,13 +2,14 @@ package eu.vendeli.rethis
 
 import com.redis.testcontainers.RedisContainer
 import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.mpp.start
 import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.testcontainers.utility.DockerImageName
 
 abstract class ReThisTestCtx(
-    withJsonModule: Boolean = false,
+    private val withJsonModule: Boolean = false,
 ) : AnnotationSpec() {
     protected val targetDb = 1L
     protected val timestamp: Instant get() = Clock.System.now()
@@ -20,12 +21,18 @@ abstract class ReThisTestCtx(
     }
 
     @Suppress("ktlint:standard:backing-property-naming")
-    private var _client = ReThis(redis.host, redis.firstMappedPort)
+    private var _client: ReThis? = null
 
-    protected val client get() = _client
+    protected val client: ReThis get() = _client!!
 
     protected fun resetClient(newClient: ReThis = ReThis(redis.host, redis.firstMappedPort)) {
         _client = newClient
+    }
+
+    @BeforeAll
+    fun beforeAll() {
+        val client = ReThis(redis.host, redis.firstMappedPort)
+        resetClient(client)
     }
 
     @AfterAll

--- a/src/jvmTest/kotlin/eu/vendeli/rethis/ReThisTestCtx.kt
+++ b/src/jvmTest/kotlin/eu/vendeli/rethis/ReThisTestCtx.kt
@@ -18,5 +18,12 @@ abstract class ReThisTestCtx(
         start()
     }
 
-    protected val client = ReThis(redis.host, redis.firstMappedPort)
+    @Suppress("ktlint:standard:backing-property-naming")
+    private var _client = ReThis(redis.host, redis.firstMappedPort)
+
+    protected val client get() = _client
+
+    protected fun resetClient(newClient: ReThis = ReThis(redis.host, redis.firstMappedPort)) {
+        _client = newClient
+    }
 }

--- a/src/jvmTest/kotlin/eu/vendeli/rethis/tests/ClientConnectionTest.kt
+++ b/src/jvmTest/kotlin/eu/vendeli/rethis/tests/ClientConnectionTest.kt
@@ -20,6 +20,7 @@ class ClientConnectionTest : ReThisTestCtx() {
 
     @Test
     suspend fun `client reconnect test`() {
+        client.reconnect()
         client.ping()
 
         client.isDisconnected shouldBe false

--- a/src/jvmTest/kotlin/eu/vendeli/rethis/tests/MultiprocessingTest.kt
+++ b/src/jvmTest/kotlin/eu/vendeli/rethis/tests/MultiprocessingTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
+@Suppress("ktlint:standard:function-naming")
 class MultiprocessingTest : ReThisTestCtx() {
     @Test
     suspend fun `multiprocessing test`() = withContext(Dispatchers.IO) {

--- a/src/jvmTest/kotlin/eu/vendeli/rethis/tests/PipeliningTest.kt
+++ b/src/jvmTest/kotlin/eu/vendeli/rethis/tests/PipeliningTest.kt
@@ -14,7 +14,7 @@ class PipeliningTest : ReThisTestCtx() {
     @Test
     suspend fun `pipelining test`() {
         val v2Client = ReThis(redis.host, redis.firstMappedPort, protocol = RespVer.V2) {
-            pool {
+            connection {
                 poolSize = 1
             }
         }

--- a/src/jvmTest/kotlin/eu/vendeli/rethis/tests/cases/TestCase.kt
+++ b/src/jvmTest/kotlin/eu/vendeli/rethis/tests/cases/TestCase.kt
@@ -57,7 +57,6 @@ class TestCase : ReThisTestCtx() {
                     client.hGet("some:key:$id", "some:field1") shouldBe "some-value1-$id"
                     client.hGet("some:key:$id", "some:field2") shouldBe "some-value2-$id"
                     client.hGet("some:key:$id", "some:field3") shouldBe "some-value3-$id"
-                    delay(100)
 
                     client.transaction {
                         del("some:key:$id")
@@ -145,7 +144,6 @@ class TestCase : ReThisTestCtx() {
                     client.hGet("some:key:$id", "some:field1") shouldBe "some-value1-$id"
                     client.hGet("some:key:$id", "some:field2") shouldBe "some-value2-$id"
                     client.hGet("some:key:$id", "some:field3") shouldBe "some-value3-$id"
-                    delay(100)
 
                     client.fastEval(
                         "script2",

--- a/src/jvmTest/kotlin/eu/vendeli/rethis/tests/cases/TestCase.kt
+++ b/src/jvmTest/kotlin/eu/vendeli/rethis/tests/cases/TestCase.kt
@@ -3,12 +3,10 @@ package eu.vendeli.rethis.tests.cases
 import eu.vendeli.rethis.ReThis
 import eu.vendeli.rethis.ReThisTestCtx
 import eu.vendeli.rethis.commands.*
-import eu.vendeli.rethis.types.core.ConnectionSource
 import eu.vendeli.rethis.types.core.RType
 import io.kotest.matchers.shouldBe
 import io.ktor.util.collections.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.time.delay
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 

--- a/src/jvmTest/kotlin/eu/vendeli/rethis/tests/commands/PubSubCommandTest.kt
+++ b/src/jvmTest/kotlin/eu/vendeli/rethis/tests/commands/PubSubCommandTest.kt
@@ -174,5 +174,6 @@ class PubSubCommandTest : ReThisTestCtx() {
         onSub shouldBeGreaterThan 0
         onUnsub shouldBe 0
         caughtEx.shouldNotBeNull().shouldBeTypeOf<ReThisException>().shouldHaveMessage("test")
+        delay(100)
     }
 }


### PR DESCRIPTION
* Moved `reconnectionStrategy` block in configuration to new `connection` block.
* Added option to set connection source, `STANDALONE` or `POOL`, for all responses in config `connection` block, or for
  transaction.
* Added `shutdown` hook.