### PR TITLE
0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Re.this Changelog
 
+## 0.3.3
+
+* Returned serialization support, with ability to use different serialization formats \
+  (through configuration `serializationFormat` parameter, or by command function parameter), \
+  supported commands `get`, `hget`, `hmget`, `hset`, `hvals`, `json.get`, `json.mget`, `json.set`, `mget`, `mset`, `set`.
+
 ## 0.3.2
 
 * Improve logging

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Get.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Get.kt
@@ -1,6 +1,7 @@
 package eu.vendeli.rethis.command.serde
 
 import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.string.get
 import eu.vendeli.rethis.shared.types.DataProcessingException
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
 import kotlinx.serialization.KSerializer

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Get.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Get.kt
@@ -1,0 +1,38 @@
+package eu.vendeli.rethis.command.serde
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.shared.types.DataProcessingException
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+suspend inline fun <reified T> ReThis.get(
+    key: String,
+): T? where T : Any {
+    return get(key, serializer<T>())
+}
+
+suspend fun <T> ReThis.get(
+    key: String,
+    serializer: KSerializer<T>,
+): T? {
+    val s: String = get(key) ?: return null
+    return try {
+        cfg.serializationFormat.deserialize(serializer, s)
+    } catch (ex: Exception) {
+        throw DataProcessingException("Failed to deserialize value for key \"$key\"", ex)
+    }
+}
+
+suspend fun <T> ReThis.get(
+    key: String,
+    serializer: KSerializer<T>,
+    format: SerializationFormat,
+): T? {
+    val s: String = get(key) ?: return null
+    return try {
+        format.deserialize(serializer, s)
+    } catch (ex: Exception) {
+        throw DataProcessingException("Failed to deserialize value for key \"$key\"", ex)
+    }
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HGet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HGet.kt
@@ -1,26 +1,28 @@
 package eu.vendeli.rethis.command.serde
 
 import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.hash.hGet
 import eu.vendeli.rethis.shared.types.DataProcessingException
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
-suspend inline fun <reified T> ReThis.get(
+suspend inline fun <reified T : Any> ReThis.hGet(
     key: String,
-): T? where T : Any {
-    return get(key, serializer<T>())
-}
+    field: String,
+): T? = hGet(key, field, serializer<T>())
 
-suspend fun <T> ReThis.get(
+suspend fun <T : Any> ReThis.hGet(
     key: String,
+    field: String,
     serializer: KSerializer<T>,
     format: SerializationFormat = cfg.serializationFormat,
 ): T? {
-    val s: String = get(key) ?: return null
+    val raw: String = hGet(key, field) ?: return null
     return try {
-        format.deserialize(serializer, s)
+        format.deserialize(serializer, raw)
     } catch (ex: Exception) {
-        throw DataProcessingException("Failed to deserialize value for key \"$key\"", ex)
+        throw DataProcessingException("Failed to deserialize hGet for key \"$key\" field \"$field\"", ex)
     }
 }
+

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HMGet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HMGet.kt
@@ -1,0 +1,31 @@
+package eu.vendeli.rethis.command.serde
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.hash.hMGet
+import eu.vendeli.rethis.shared.types.DataProcessingException
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+
+suspend inline fun <reified T : Any> ReThis.hMGet(
+    key: String,
+    vararg field: String,
+): List<T?> = hMGet(key = key, field = field, serializer = serializer<T>())
+
+suspend fun <T : Any> ReThis.hMGet(
+    key: String,
+    vararg field: String,
+    serializer: KSerializer<T>,
+    format: SerializationFormat = cfg.serializationFormat,
+): List<T?> {
+    val raw: List<String?> = hMGet(key, *field)
+    return raw.map { string ->
+        if (string == null) return@map null
+        try {
+            format.deserialize(serializer, string)
+        } catch (ex: Exception) {
+            throw DataProcessingException("Failed to deserialize hMGet for key \"$key\"", ex)
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HMSet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HMSet.kt
@@ -1,0 +1,25 @@
+package eu.vendeli.rethis.command.serde
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.hash.hMSet
+import eu.vendeli.rethis.shared.request.common.FieldValue
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+suspend inline fun <reified T : Any> ReThis.hMSet(
+    key: String,
+    vararg fieldValue: Pair<String, T>,
+): Boolean = hMSet(key, fieldValue = fieldValue, serializer<T>())
+
+suspend fun <T : Any> ReThis.hMSet(
+    key: String,
+    vararg fieldValue: Pair<String, T>,
+    serializer: KSerializer<T>,
+    format: SerializationFormat = cfg.serializationFormat,
+): Boolean {
+    val serializedPairs = fieldValue.map { (f, v) ->
+        FieldValue(f, format.serialize(serializer, v))
+    }.toTypedArray()
+    return hMSet(key = key, data = serializedPairs)
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HSet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HSet.kt
@@ -1,25 +1,27 @@
 package eu.vendeli.rethis.command.serde
 
 import eu.vendeli.rethis.ReThis
-import eu.vendeli.rethis.command.hash.hMSet
+import eu.vendeli.rethis.command.hash.hSet
 import eu.vendeli.rethis.shared.request.common.FieldValue
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
-suspend inline fun <reified T : Any> ReThis.hMSet(
+suspend inline fun <reified T : Any> ReThis.hSet(
     key: String,
     vararg fieldValue: Pair<String, T>,
-): Boolean = hMSet(key, fieldValue = fieldValue, serializer<T>())
+): Long = hSet(key, fieldValue = fieldValue, serializer<T>())
 
-suspend fun <T : Any> ReThis.hMSet(
+suspend fun <T : Any> ReThis.hSet(
     key: String,
     vararg fieldValue: Pair<String, T>,
     serializer: KSerializer<T>,
     format: SerializationFormat = cfg.serializationFormat,
-): Boolean {
+): Long {
     val serializedPairs = fieldValue.map { (f, v) ->
         FieldValue(f, format.serialize(serializer, v))
     }.toTypedArray()
-    return hMSet(key = key, data = serializedPairs)
+    return hSet(key = key, data = serializedPairs)
 }
+
+

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HVals.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HVals.kt
@@ -1,0 +1,27 @@
+package eu.vendeli.rethis.command.serde
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.hash.hVals
+import eu.vendeli.rethis.shared.types.DataProcessingException
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+suspend inline fun <reified T : Any> ReThis.hVals(
+    key: String,
+): List<T> = hVals(key, serializer<T>())
+
+suspend fun <T : Any> ReThis.hVals(
+    key: String,
+    serializer: KSerializer<T>,
+    format: SerializationFormat = cfg.serializationFormat,
+): List<T> {
+    val raw: List<String> = hVals(key)
+    return raw.map { s ->
+        try {
+            format.deserialize(serializer, s)
+        } catch (ex: Exception) {
+            throw DataProcessingException("Failed to deserialize hVals for key \"$key\"", ex)
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HVals.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HVals.kt
@@ -17,9 +17,9 @@ suspend fun <T : Any> ReThis.hVals(
     format: SerializationFormat = cfg.serializationFormat,
 ): List<T> {
     val raw: List<String> = hVals(key)
-    return raw.map { s ->
+    return raw.map { string ->
         try {
-            format.deserialize(serializer, s)
+            format.deserialize(serializer, string)
         } catch (ex: Exception) {
             throw DataProcessingException("Failed to deserialize hVals for key \"$key\"", ex)
         }

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonGet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonGet.kt
@@ -1,0 +1,28 @@
+package eu.vendeli.rethis.command.serde
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.json.jsonGet
+import eu.vendeli.rethis.shared.request.json.JsonGetOption
+import eu.vendeli.rethis.shared.types.DataProcessingException
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+suspend inline fun <reified T : Any> ReThis.jsonGet(
+    key: String,
+    vararg options: JsonGetOption,
+): T? = jsonGet(key = key, options = options, serializer = serializer<T>())
+
+suspend fun <T : Any> ReThis.jsonGet(
+    key: String,
+    vararg options: JsonGetOption,
+    serializer: KSerializer<T>,
+    format: SerializationFormat = cfg.serializationFormat,
+): T? {
+    val raw: String = jsonGet(key = key, options = options) ?: return null
+    return try {
+        format.deserialize(serializer, raw)
+    } catch (ex: Exception) {
+        throw DataProcessingException("Failed to deserialize jsonGet for key \"$key\"", ex)
+    }
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonMGet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonMGet.kt
@@ -1,0 +1,30 @@
+package eu.vendeli.rethis.command.serde
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.json.jsonMGet
+import eu.vendeli.rethis.shared.types.DataProcessingException
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+suspend inline fun <reified T : Any> ReThis.jsonMGet(
+    path: String,
+    vararg key: String,
+): List<T?> = jsonMGet(path = path, key = key, serializer = serializer<T>())
+
+suspend fun <T : Any> ReThis.jsonMGet(
+    path: String,
+    vararg key: String,
+    serializer: KSerializer<T>,
+    format: SerializationFormat = cfg.serializationFormat,
+): List<T?> {
+    val raw: List<String?> = jsonMGet(path, *key)
+    return raw.map { string ->
+        if (string == null) return@map null
+        try {
+            format.deserialize(serializer, string)
+        } catch (ex: Exception) {
+            throw DataProcessingException("Failed to deserialize jsonMGet for path \"$path\"", ex)
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonSet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonSet.kt
@@ -1,0 +1,29 @@
+package eu.vendeli.rethis.command.serde
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.json.jsonSet
+import eu.vendeli.rethis.shared.request.string.UpsertMode
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import eu.vendeli.rethis.utils.JSON_DEFAULT_PATH
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+suspend inline fun <reified T : Any> ReThis.jsonSet(
+    key: String,
+    value: T,
+    path: String = JSON_DEFAULT_PATH,
+    upsertMode: UpsertMode? = null,
+): String = jsonSet(key, value, serializer<T>(), path, upsertMode)
+
+suspend fun <T : Any> ReThis.jsonSet(
+    key: String,
+    value: T,
+    serializer: KSerializer<T>,
+    path: String = JSON_DEFAULT_PATH,
+    upsertMode: UpsertMode? = null,
+    format: SerializationFormat = cfg.serializationFormat,
+): String {
+    val serialized = format.serialize(serializer, value)
+    return jsonSet(key, serialized, path, upsertMode)
+}
+

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Mget.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Mget.kt
@@ -1,0 +1,29 @@
+package eu.vendeli.rethis.command.serde
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.string.mGet
+import eu.vendeli.rethis.shared.types.DataProcessingException
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+suspend inline fun <reified T : Any> ReThis.mGet(
+    vararg key: String,
+): List<T?> = mGet(key = key, serializer = serializer<T>())
+
+suspend fun <T : Any> ReThis.mGet(
+    vararg key: String,
+    serializer: KSerializer<T>,
+    format: SerializationFormat = cfg.serializationFormat,
+): List<T?> {
+    val raw: List<String?> = mGet(*key)
+    return raw.map { string ->
+        if (string == null) return@map null
+        try {
+            format.deserialize(serializer, string)
+        } catch (ex: Exception) {
+            throw DataProcessingException("Failed to deserialize value for mGet", ex)
+        }
+    }
+}
+

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Mset.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Mset.kt
@@ -1,0 +1,23 @@
+package eu.vendeli.rethis.command.serde
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.string.mSet
+import eu.vendeli.rethis.shared.request.string.KeyValue
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+suspend inline fun <reified T : Any> ReThis.mSet(
+    vararg kvPair: Pair<String, T>,
+): Boolean = mSet(kvPair = kvPair, serializer = serializer<T>())
+
+suspend fun <T : Any> ReThis.mSet(
+    vararg kvPair: Pair<String, T>,
+    serializer: KSerializer<T>,
+    format: SerializationFormat = cfg.serializationFormat,
+): Boolean {
+    val serializedPairs = kvPair.map { (k, v) ->
+        KeyValue(k, format.serialize(serializer, v))
+    }.toTypedArray()
+    return mSet(*serializedPairs)
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Set.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Set.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.serializer
 suspend inline fun <reified T> ReThis.`set`(
     key: String,
     value: T,
-    vararg options: SetOption
+    vararg options: SetOption,
 ): String? where T : Any {
     return set(key, value, serializer<T>(), *options)
 }
@@ -18,18 +18,8 @@ suspend fun <T> ReThis.`set`(
     key: String,
     value: T,
     serializer: KSerializer<T>,
-    vararg options: SetOption
-): String? {
-    val value = cfg.serializationFormat.serialize(serializer, value)
-    return set(key, value, *options)
-}
-
-suspend fun <T> ReThis.`set`(
-    key: String,
-    value: T,
-    serializer: KSerializer<T>,
-    serializationFormat: SerializationFormat,
-    vararg options: SetOption
+    vararg options: SetOption,
+    serializationFormat: SerializationFormat = cfg.serializationFormat,
 ): String? {
     val value = serializationFormat.serialize(serializer, value)
     return set(key, value, *options)

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Set.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Set.kt
@@ -1,0 +1,36 @@
+package eu.vendeli.rethis.command.serde
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.shared.request.string.SetOption
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+suspend inline fun <reified T> ReThis.`set`(
+    key: String,
+    value: T,
+    vararg options: SetOption
+): String? where T : Any {
+    return set(key, value, serializer<T>(), *options)
+}
+
+suspend fun <T> ReThis.`set`(
+    key: String,
+    value: T,
+    serializer: KSerializer<T>,
+    vararg options: SetOption
+): String? {
+    val value = cfg.serializationFormat.serialize(serializer, value)
+    return set(key, value, *options)
+}
+
+suspend fun <T> ReThis.`set`(
+    key: String,
+    value: T,
+    serializer: KSerializer<T>,
+    serializationFormat: SerializationFormat,
+    vararg options: SetOption
+): String? {
+    val value = serializationFormat.serialize(serializer, value)
+    return set(key, value, *options)
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Set.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Set.kt
@@ -1,6 +1,7 @@
 package eu.vendeli.rethis.command.serde
 
 import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.string.set
 import eu.vendeli.rethis.shared.request.string.SetOption
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
 import kotlinx.serialization.KSerializer

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/configuration/ReThisConfiguration.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/configuration/ReThisConfiguration.kt
@@ -2,10 +2,12 @@ package eu.vendeli.rethis.configuration
 
 import eu.vendeli.rethis.annotations.ConfigurationDSL
 import eu.vendeli.rethis.core.DefaultLoggerFactory
-import eu.vendeli.rethis.types.common.LoggerFactory
+import eu.vendeli.rethis.core.JsonSerializationFormat
+import eu.vendeli.rethis.types.interfaces.LoggerFactory
 import eu.vendeli.rethis.types.common.ReadFrom
-import eu.vendeli.rethis.types.common.ReadFromStrategy
+import eu.vendeli.rethis.types.interfaces.ReadFromStrategy
 import eu.vendeli.rethis.types.common.RespVer
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
 import io.ktor.network.tls.*
 import io.ktor.utils.io.charsets.*
 import kotlinx.coroutines.CoroutineDispatcher
@@ -120,6 +122,18 @@ sealed class ReThisConfiguration(internal val protocol: RespVer) {
      * it uses `DefaultLoggerFactory`.
      */
     var loggerFactory: LoggerFactory = DefaultLoggerFactory
+
+    /**
+     * Specifies the serialization format used for serializing and deserializing values in the Redis client.
+     *
+     * This property determines how objects are transformed into strings to be stored in Redis and
+     * how strings retrieved from Redis are converted back into objects. By default, it is configured
+     * to use a JSON-based serialization format provided by [JsonSerializationFormat].
+     *
+     * You can customize this property to use a different implementation of [SerializationFormat],
+     * enabling support for other serialization mechanisms as required.
+     */
+    var serializationFormat: SerializationFormat = JsonSerializationFormat()
 
     /**
      * Configures authentication for the Redis connection by setting the password and optional username.

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/core/DefaultLoggerFactory.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/core/DefaultLoggerFactory.kt
@@ -1,6 +1,6 @@
 package eu.vendeli.rethis.core
 
-import eu.vendeli.rethis.types.common.LoggerFactory
+import eu.vendeli.rethis.types.interfaces.LoggerFactory
 import io.ktor.util.logging.*
 
 object DefaultLoggerFactory : LoggerFactory {

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/core/JsonSerializationFormat.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/core/JsonSerializationFormat.kt
@@ -2,14 +2,21 @@ package eu.vendeli.rethis.core
 
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 
 class JsonSerializationFormat(
-  private val json: Json = Json { encodeDefaults = true }
-): SerializationFormat {
-  override fun <T> serialize(serializer: KSerializer<T>, value: T): String =
-    json.encodeToString(serializer, value)
+    private val json: Json = Json { encodeDefaults = true },
+) : SerializationFormat {
+    override fun <T> serialize(serializer: KSerializer<T>, value: T): String =
+        json.encodeToString(serializer, value)
 
-  override fun <T> deserialize(serializer: KSerializer<T>, string: String): T =
-    json.decodeFromString(serializer, string)
+    override fun <T> deserialize(serializer: KSerializer<T>, string: String): T {
+        return if (serializer == String.serializer()) {
+            @Suppress("UNCHECKED_CAST")
+            return string as T
+        } else {
+            json.decodeFromString(serializer, string)
+        }
+    }
 }

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/core/JsonSerializationFormat.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/core/JsonSerializationFormat.kt
@@ -1,0 +1,15 @@
+package eu.vendeli.rethis.core
+
+import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+
+class JsonSerializationFormat(
+  private val json: Json = Json { encodeDefaults = true }
+): SerializationFormat {
+  override fun <T> serialize(serializer: KSerializer<T>, value: T): String =
+    json.encodeToString(serializer, value)
+
+  override fun <T> deserialize(serializer: KSerializer<T>, string: String): T =
+    json.decodeFromString(serializer, string)
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/types/common/LoggerFactory.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/types/common/LoggerFactory.kt
@@ -1,7 +1,0 @@
-package eu.vendeli.rethis.types.common
-
-import io.ktor.util.logging.*
-
-fun interface LoggerFactory {
-    fun get(name: String): Logger
-}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/types/common/ReadFrom.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/types/common/ReadFrom.kt
@@ -2,6 +2,7 @@ package eu.vendeli.rethis.types.common
 
 import eu.vendeli.rethis.providers.ConnectionProvider
 import eu.vendeli.rethis.shared.types.CommandRequest
+import eu.vendeli.rethis.types.interfaces.ReadFromStrategy
 
 sealed class ReadFrom : ReadFromStrategy {
     object Master : ReadFromStrategy {

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/types/interfaces/LoggerFactory.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/types/interfaces/LoggerFactory.kt
@@ -1,0 +1,7 @@
+package eu.vendeli.rethis.types.interfaces
+
+import io.ktor.util.logging.Logger
+
+fun interface LoggerFactory {
+    fun get(name: String): Logger
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/types/interfaces/ReadFromStrategy.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/types/interfaces/ReadFromStrategy.kt
@@ -1,8 +1,9 @@
-package eu.vendeli.rethis.types.common
+package eu.vendeli.rethis.types.interfaces
 
 import eu.vendeli.rethis.providers.ConnectionProvider
 import eu.vendeli.rethis.shared.types.CommandRequest
+import eu.vendeli.rethis.types.common.Snapshot
 
-sealed interface ReadFromStrategy {
+interface ReadFromStrategy {
     fun pick(request: CommandRequest, snapshot: Snapshot): ConnectionProvider
 }

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/types/interfaces/SerializationFormat.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/types/interfaces/SerializationFormat.kt
@@ -1,0 +1,8 @@
+package eu.vendeli.rethis.types.interfaces
+
+import kotlinx.serialization.KSerializer
+
+interface SerializationFormat {
+    fun <T> serialize(serializer: KSerializer<T>, value: T): String
+    fun <T> deserialize(serializer: KSerializer<T>, string: String): T
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/utils/Const.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/utils/Const.kt
@@ -6,4 +6,6 @@ const val CLIENT_NAME: String = "Re.This"
 const val DEFAULT_HOST: String = "127.0.0.1"
 const val DEFAULT_PORT: Int = 6379
 
+const val JSON_DEFAULT_PATH = "."
+
 val EOL: ByteArray = "\r\n".toByteArray()

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/utils/RawReqUtils.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/utils/RawReqUtils.kt
@@ -53,3 +53,15 @@ fun List<Any?>.toRESPBuffer(charset: Charset = Charsets.UTF_8): Buffer {
 @ReThisInternal
 suspend fun ReThis.execute(requestBlock: MutableList<Any?>.() -> Unit): Buffer =
     execute(buildList(requestBlock).toRESPBuffer())
+
+/**
+ * Retrieves the serialization format specified in the configuration of the current `ReThis` instance.
+ * This is used to determine how data is serialized or deserialized within the `ReThis` framework.
+ *
+ * Note: This function is marked as an internal API and is not intended for external usage. It may
+ * be subject to change or removal without notice.
+ *
+ * @return The serialization format defined in the configuration.
+ */
+@ReThisInternal
+fun ReThis.serdeModule() = cfg.serializationFormat

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/HashSerdeCommandsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/HashSerdeCommandsTest.kt
@@ -1,6 +1,7 @@
 package eu.vendeli.rethis.serde
 
 import eu.vendeli.rethis.ReThisTestCtx
+import eu.vendeli.rethis.command.hash.hDel
 import eu.vendeli.rethis.command.serde.hGet
 import eu.vendeli.rethis.command.serde.hSet
 import eu.vendeli.rethis.command.serde.hVals
@@ -44,7 +45,8 @@ class HashSerdeCommandsTest : ReThisTestCtx() {
         val result = client.hVals<String>(key)
         result shouldBe listOf(value1.quote(), encodedEntity)
 
+        client.hDel(key, field1)
         val serializedResult = client.hVals(key, TestData.serializer())
-        serializedResult shouldBe listOf(value1, value2)
+        serializedResult.single() shouldBe TestData(entity.first, entity.second)
     }
 }

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/HashSerdeCommandsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/HashSerdeCommandsTest.kt
@@ -1,58 +1,32 @@
 package eu.vendeli.rethis.serde
 
 import eu.vendeli.rethis.ReThisTestCtx
-import eu.vendeli.rethis.command.hash.hMSet
-import eu.vendeli.rethis.command.hash.hSet
 import eu.vendeli.rethis.command.serde.hGet
-import eu.vendeli.rethis.command.serde.hMGet
+import eu.vendeli.rethis.command.serde.hSet
 import eu.vendeli.rethis.command.serde.hVals
-import eu.vendeli.rethis.shared.request.common.FieldValue
 import io.kotest.matchers.shouldBe
+import io.ktor.http.quote
+import kotlinx.serialization.builtins.PairSerializer
+import kotlinx.serialization.builtins.serializer
 
 class HashSerdeCommandsTest : ReThisTestCtx() {
     private val encodedEntity = """{"first":"testValue","second":2}"""
+    private val entity = "testValue" to 2
 
     @Test
     suspend fun `test hGet`() {
         val key = "testKey1"
         val field = "testField"
-        val value = "testValue"
+        val value = entity
 
-        client.hSet(key, FieldValue(field, value))
+        client.hSet(key, field to value)
 
         val result = client.hGet<String>(key, field)
         result shouldBe encodedEntity
-    }
 
-    @Test
-    suspend fun `test hMGet`() {
-        val key = "testKey2"
-        val field1 = "testField1"
-        val value1 = "testValue1"
-
-        val field2 = "testField2"
-        val value2 = "testValue2"
-
-        client.hSet(key, FieldValue(field1, value1))
-        client.hSet(key, FieldValue(field2, value2))
-
-        val result = client.hMGet<String>(key, field1, field2)
-        result shouldBe listOf(value1, encodedEntity)
-    }
-
-    @Test
-    suspend fun `test hMSet`() {
-        val key = "testKey3"
-        val field1 = "testField1"
-
-        val field2 = "testField2"
-        val value2 = "testValue2"
-
-        val result = client.hMSet(key, FieldValue(field2, value2))
-        result shouldBe true
-
-        val values = client.hMGet<String>(key, field1, field2)
-        values shouldBe listOf(null, encodedEntity)
+        val serializer = PairSerializer(String.serializer(), Int.serializer())
+        val serializedResult = client.hGet(key, field, serializer)
+        serializedResult shouldBe entity
     }
 
     @Test
@@ -62,12 +36,15 @@ class HashSerdeCommandsTest : ReThisTestCtx() {
         val value1 = "testValue1"
 
         val field2 = "testField2"
-        val value2 = "testValue2"
+        val value2 = entity
 
-        client.hSet(key, FieldValue(field1, value1))
-        client.hSet(key, FieldValue(field2, value2))
+        client.hSet(key, field1 to value1)
+        client.hSet(key, field2 to value2)
 
         val result = client.hVals<String>(key)
-        result shouldBe listOf(value1, encodedEntity)
+        result shouldBe listOf(value1.quote(), encodedEntity)
+
+        val serializedResult = client.hVals(key, TestData.serializer())
+        serializedResult shouldBe listOf(value1, value2)
     }
 }

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/HashSerdeCommandsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/HashSerdeCommandsTest.kt
@@ -1,69 +1,73 @@
-//package eu.vendeli.rethis.serde
-//
-//import eu.vendeli.rethis.ReThisTestCtx
-//import eu.vendeli.rethis.commands.*
-//import io.kotest.matchers.shouldBe
-//
-//class HashSerdeCommandsTest : ReThisTestCtx() {
-//    private val entity = "testValue" to 2
-//    private val encodedEntity = """{"first":"testValue","second":2}"""
-//
-//    @Test
-//    suspend fun `test hGet`() {
-//        val key = "testKey1"
-//        val field = "testField"
-//        val value = entity
-//
-//        client.hSet(key, field to value)
-//
-//        val result = client.hGet<String>(key, field)
-//        result shouldBe encodedEntity
-//    }
-//
-//    @Test
-//    suspend fun `test hMGet`() {
-//        val key = "testKey2"
-//        val field1 = "testField1"
-//        val value1 = "testValue1"
-//
-//        val field2 = "testField2"
-//        val value2 = entity
-//
-//        client.hSet(key, field1 to value1)
-//        client.hSet(key, field2 to value2)
-//
-//        val result = client.hMGet<String>(key, field1, field2)
-//        result shouldBe listOf(value1, encodedEntity)
-//    }
-//
-//    @Test
-//    suspend fun `test hMSet`() {
-//        val key = "testKey3"
-//        val field1 = "testField1"
-//
-//        val field2 = "testField2"
-//        val value2 = entity
-//
-//        val result = client.hMSet(key, field2 to value2)
-//        result shouldBe true
-//
-//        val values = client.hMGet<String>(key, field1, field2)
-//        values shouldBe listOf(null, encodedEntity)
-//    }
-//
-//    @Test
-//    suspend fun `test hVals`() {
-//        val key = "testKey5"
-//        val field1 = "testField1"
-//        val value1 = "testValue1"
-//
-//        val field2 = "testField2"
-//        val value2 = entity
-//
-//        client.hSet(key, field1 to value1)
-//        client.hSet(key, field2 to value2)
-//
-//        val result = client.hVals<String>(key)
-//        result shouldBe listOf(value1, encodedEntity)
-//    }
-//}
+package eu.vendeli.rethis.serde
+
+import eu.vendeli.rethis.ReThisTestCtx
+import eu.vendeli.rethis.command.hash.hMSet
+import eu.vendeli.rethis.command.hash.hSet
+import eu.vendeli.rethis.command.serde.hGet
+import eu.vendeli.rethis.command.serde.hMGet
+import eu.vendeli.rethis.command.serde.hVals
+import eu.vendeli.rethis.shared.request.common.FieldValue
+import io.kotest.matchers.shouldBe
+
+class HashSerdeCommandsTest : ReThisTestCtx() {
+    private val encodedEntity = """{"first":"testValue","second":2}"""
+
+    @Test
+    suspend fun `test hGet`() {
+        val key = "testKey1"
+        val field = "testField"
+        val value = "testValue"
+
+        client.hSet(key, FieldValue(field, value))
+
+        val result = client.hGet<String>(key, field)
+        result shouldBe encodedEntity
+    }
+
+    @Test
+    suspend fun `test hMGet`() {
+        val key = "testKey2"
+        val field1 = "testField1"
+        val value1 = "testValue1"
+
+        val field2 = "testField2"
+        val value2 = "testValue2"
+
+        client.hSet(key, FieldValue(field1, value1))
+        client.hSet(key, FieldValue(field2, value2))
+
+        val result = client.hMGet<String>(key, field1, field2)
+        result shouldBe listOf(value1, encodedEntity)
+    }
+
+    @Test
+    suspend fun `test hMSet`() {
+        val key = "testKey3"
+        val field1 = "testField1"
+
+        val field2 = "testField2"
+        val value2 = "testValue2"
+
+        val result = client.hMSet(key, FieldValue(field2, value2))
+        result shouldBe true
+
+        val values = client.hMGet<String>(key, field1, field2)
+        values shouldBe listOf(null, encodedEntity)
+    }
+
+    @Test
+    suspend fun `test hVals`() {
+        val key = "testKey5"
+        val field1 = "testField1"
+        val value1 = "testValue1"
+
+        val field2 = "testField2"
+        val value2 = "testValue2"
+
+        client.hSet(key, FieldValue(field1, value1))
+        client.hSet(key, FieldValue(field2, value2))
+
+        val result = client.hVals<String>(key)
+        result shouldBe listOf(value1, encodedEntity)
+    }
+}

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/JsonSerdeCommandsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/JsonSerdeCommandsTest.kt
@@ -1,121 +1,129 @@
-//package eu.vendeli.rethis.serde
-//
-//import eu.vendeli.rethis.ReThisTestCtx
-//import eu.vendeli.rethis.commands.jsonArrPop
-//import eu.vendeli.rethis.commands.jsonGet
-//import eu.vendeli.rethis.commands.jsonMGet
-//import eu.vendeli.rethis.commands.jsonSet
-//import eu.vendeli.rethis.shared.types.RArray
-//import eu.vendeli.rethis.utils.__jsonModule
-//import eu.vendeli.rethis.utils.unwrap
-//import io.kotest.matchers.collections.shouldHaveSize
-//import io.kotest.matchers.nulls.shouldNotBeNull
-//import io.kotest.matchers.shouldBe
-//import io.kotest.matchers.types.shouldBeTypeOf
-//import kotlinx.serialization.Serializable
-//
-//class JsonSerdeCommandsTest : ReThisTestCtx(true) {
-//    @Serializable
-//    data class User(
-//        val id: Int,
-//        val name: String,
-//    )
-//
-//    @Serializable
-//    data class MixedData(
-//        val str: String,
-//        val user: User,
-//        val number: Double,
-//    )
-//
-//    @Test
-//    suspend fun `test json set with default path`() {
-//        val key = "defaultPathKey"
-//        val user = User(794, "Sam")
-//
-//        client.jsonSet(key, value = user)
-//
-//        client.jsonGet<User>(key) shouldBe user
-//    }
-//
-//    @Test
-//    suspend fun `test heterogeneous structures using wrapper objects`() {
-//        val key = "mixedKey"
-//        val data = MixedData(
-//            str = "test",
-//            user = User(3, "Charlie"),
-//            number = 3.14,
-//        )
-//
-//        client.jsonSet(key, data)
-//
-//        // Access individual fields with proper types
-//        client.jsonGet<String>(key, "$.str") shouldBe "[\"test\"]"
-//        client.jsonGet<List<User>>(key, "$.user") shouldBe listOf(User(3, "Charlie"))
-//        client.jsonGet<List<Double>>(key, "$.number") shouldBe listOf(3.14)
-//    }
-//
-//    @Test
-//    suspend fun `test nested arrays with typed elements`() {
-//        @Serializable
-//        data class NestedUserList(
-//            val users: List<User>,
-//        )
-//
-//        val key = "nestedArrayKey"
-//        val data = NestedUserList(
-//            users = listOf(
-//                User(4, "David"),
-//                User(5, "Eve"),
-//            ),
-//        )
-//
-//        client.jsonSet(key, data)
-//
-//        // Pop from nested array
-//        client.jsonArrPop(key, "$.users").shouldBeTypeOf<RArray>().value.shouldNotBeNull().first().let {
-//            client.__jsonModule().decodeFromString<User>(it.unwrap<String>()!!)
-//        } shouldBe User(5, "Eve")
-//        client.jsonGet<NestedUserList>(key) shouldBe NestedUserList(
-//            users = listOf(User(4, "David")),
-//        )
-//    }
-//
-//    @Test
-//    suspend fun `test jsonMGet with typed paths`() {
-//        val key = "dataKey"
-//        val data = mapOf(
-//            "adam" to User(1, "Adam"),
-//            "eve" to User(2, "Eve"),
-//        )
-//
-//        val key2 = "dataKey2"
-//        val data2 = mapOf(
-//            "joanna" to User(3, "Joanna"),
-//            "jey" to User(4, "Jey"),
-//        )
-//
-//        client.jsonSet(key, data)
-//        client.jsonSet(key2, data2)
-//
-//        // Query multiple paths with proper types
-//        val results = client.jsonMGet<List<Int>>(
-//            path = "$.*.id",
-//            key,
-//            key2,
-//        )
-//
-//        // Verify results with type casting
-//        val result = results.shouldNotBeNull().shouldHaveSize(2)
-//
-//        result.first().shouldNotBeNull().shouldHaveSize(2).run {
-//            first().shouldNotBeNull() shouldBe 1
-//            last().shouldNotBeNull() shouldBe 2
-//        }
-//
-//        result.last().shouldNotBeNull().shouldHaveSize(2).run {
-//            first().shouldNotBeNull() shouldBe 3
-//            last().shouldNotBeNull() shouldBe 4
-//        }
-//    }
-//}
+package eu.vendeli.rethis.serde
+
+import eu.vendeli.rethis.ReThisTestCtx
+import eu.vendeli.rethis.command.json.jsonArrPop
+import eu.vendeli.rethis.command.json.jsonSet
+import eu.vendeli.rethis.command.serde.jsonGet
+import eu.vendeli.rethis.command.serde.jsonMGet
+import eu.vendeli.rethis.command.serde.jsonSet
+import eu.vendeli.rethis.shared.request.json.JsonGetOption
+import eu.vendeli.rethis.shared.types.PlainString
+import eu.vendeli.rethis.shared.types.RArray
+import eu.vendeli.rethis.shared.utils.unwrap
+import eu.vendeli.rethis.utils.serdeModule
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import kotlinx.serialization.Serializable
+
+class JsonSerdeCommandsTest : ReThisTestCtx(true) {
+    @Serializable
+    data class User(
+        val id: Int,
+        val name: String,
+    )
+
+    @Serializable
+    data class MixedData(
+        val str: String,
+        val user: User,
+        val number: Double,
+    )
+
+    @Test
+    suspend fun `test json set with default path`() {
+        val key = "defaultPathKey"
+        val user = User(794, "Sam")
+
+        client.jsonSet(key, value = user)
+
+        client.jsonGet<User>(key) shouldBe user
+    }
+
+    @Test
+    suspend fun `test heterogeneous structures using wrapper objects`() {
+        val key = "mixedKey"
+        val data = MixedData(
+            str = "test",
+            user = User(3, "Charlie"),
+            number = 3.14,
+        )
+
+        client.jsonSet("a", "v")
+        client.jsonSet(key, data)
+
+        // Access individual fields with proper types
+        client.jsonGet<String>(key, JsonGetOption.Paths("$.str")) shouldBe "[\"test\"]"
+        client.jsonGet<List<User>>(key, JsonGetOption.Paths("$.user")) shouldBe listOf(User(3, "Charlie"))
+        client.jsonGet<List<Double>>(key, JsonGetOption.Paths("$.number")) shouldBe listOf(3.14)
+    }
+
+    @Test
+    suspend fun `test nested arrays with typed elements`() {
+        @Serializable
+        data class NestedUserList(
+            val users: List<User>,
+        )
+
+        val key = "nestedArrayKey"
+        val data = NestedUserList(
+            users = listOf(
+                User(4, "David"),
+                User(5, "Eve"),
+            ),
+        )
+
+        client.jsonSet(key, data)
+
+        // Pop from nested array
+        client.jsonArrPop(key, "$.users")
+            .shouldBeTypeOf<RArray>()
+            .value
+            .first()
+            .shouldBeTypeOf<PlainString>().let {
+                client.serdeModule().deserialize(User.serializer(), it.unwrap<String>()!!)
+            } shouldBe User(5, "Eve")
+        client.jsonGet<NestedUserList>(key) shouldBe NestedUserList(
+            users = listOf(User(4, "David")),
+        )
+    }
+
+    @Test
+    suspend fun `test jsonMGet with typed paths`() {
+        val key = "dataKey"
+        val data = mapOf(
+            "adam" to User(1, "Adam"),
+            "eve" to User(2, "Eve"),
+        )
+
+        val key2 = "dataKey2"
+        val data2 = mapOf(
+            "joanna" to User(3, "Joanna"),
+            "jey" to User(4, "Jey"),
+        )
+
+        client.jsonSet(key, data)
+        client.jsonSet(key2, data2)
+
+        // Query multiple paths with proper types
+        val results = client.jsonMGet<List<Int>>(
+            path = "$.*.id",
+            key,
+            key2,
+        )
+
+        // Verify results with type casting
+        val result = results.shouldNotBeNull().shouldHaveSize(2)
+
+        result.first().shouldNotBeNull().shouldHaveSize(2).run {
+            first().shouldNotBeNull() shouldBe 1
+            last().shouldNotBeNull() shouldBe 2
+        }
+
+        result.last().shouldNotBeNull().shouldHaveSize(2).run {
+            first().shouldNotBeNull() shouldBe 3
+            last().shouldNotBeNull() shouldBe 4
+        }
+    }
+}

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/JsonSerdeCommandsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/JsonSerdeCommandsTest.kt
@@ -7,7 +7,7 @@ import eu.vendeli.rethis.command.serde.jsonGet
 import eu.vendeli.rethis.command.serde.jsonMGet
 import eu.vendeli.rethis.command.serde.jsonSet
 import eu.vendeli.rethis.shared.request.json.JsonGetOption
-import eu.vendeli.rethis.shared.types.PlainString
+import eu.vendeli.rethis.shared.types.BulkString
 import eu.vendeli.rethis.shared.types.RArray
 import eu.vendeli.rethis.shared.utils.unwrap
 import eu.vendeli.rethis.utils.serdeModule
@@ -81,7 +81,7 @@ class JsonSerdeCommandsTest : ReThisTestCtx(true) {
             .shouldBeTypeOf<RArray>()
             .value
             .first()
-            .shouldBeTypeOf<PlainString>().let {
+            .shouldBeTypeOf<BulkString>().let {
                 client.serdeModule().deserialize(User.serializer(), it.unwrap<String>()!!)
             } shouldBe User(5, "Eve")
         client.jsonGet<NestedUserList>(key) shouldBe NestedUserList(

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/JsonSerdeCommandsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/JsonSerdeCommandsTest.kt
@@ -50,7 +50,6 @@ class JsonSerdeCommandsTest : ReThisTestCtx(true) {
             number = 3.14,
         )
 
-        client.jsonSet("a", "v")
         client.jsonSet(key, data)
 
         // Access individual fields with proper types

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/StringSerdeCommandsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/StringSerdeCommandsTest.kt
@@ -9,10 +9,8 @@ import eu.vendeli.rethis.utils.serdeModule
 import io.kotest.matchers.shouldBe
 
 class StringSerdeCommandsTest : ReThisTestCtx() {
+    private val encodedEntity = """{"first":"testValue","second":2}"""
     private val entity = TestData("testValue", 2)
-    private val encodedEntity by lazy {
-        client.serdeModule().serialize(TestData.serializer(), entity)
-    }
 
     @Test
     suspend fun `test set and get`() {

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/StringSerdeCommandsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/StringSerdeCommandsTest.kt
@@ -1,93 +1,51 @@
-//package eu.vendeli.rethis.serde
-//
-//import eu.vendeli.rethis.ReThisTestCtx
-//import eu.vendeli.rethis.commands.*
-//import eu.vendeli.rethis.types.options.GetExOption
-//import eu.vendeli.rethis.utils.__jsonModule
-//import io.kotest.matchers.longs.shouldBeInRange
-//import io.kotest.matchers.nulls.shouldNotBeNull
-//import io.kotest.matchers.shouldBe
-//import kotlin.time.Duration.Companion.seconds
-//
-//class StringSerdeCommandsTest : ReThisTestCtx() {
-//    private val entity = TestData("testValue", 2)
-//    private val encodedEntity by lazy { client.__jsonModule().encodeToString(entity) }
-//
-//    @Test
-//    suspend fun `test set and get`() {
-//        val key = "testKeySet"
-//
-//        client.set(key, entity)
-//
-//        // Test retrieving as JSON string
-//        val jsonResult = client.get<String>(key)
-//        jsonResult shouldBe encodedEntity
-//
-//        // Test retrieving as deserialized object
-//        val objResult = client.get<TestData>(key)
-//        objResult shouldBe entity
-//    }
-//
-//    @Test
-//    suspend fun `test mSet and mGet`() {
-//        val key1 = "testKeyM1"
-//        val key2 = "testKeyM2"
-//        val value2 = TestData(key2, 8)
-//
-//        client.mSet(key1 to entity, key2 to value2)
-//
-//        // Test multi-get as JSON strings
-//        val jsonResults = client.mGet<String>(key1, key2)
-//        jsonResults shouldBe listOf(encodedEntity, client.__jsonModule().encodeToString(value2))
-//
-//        // Test multi-get as objects
-//        val objResults = client.mGet<TestData>(key1, key2)
-//        objResults shouldBe listOf(entity, value2)
-//    }
-//
-//    @Test
-//    suspend fun `test getDel`() {
-//        val key = "testKeyGetDel"
-//
-//        client.set(key, entity)
-//
-//        // Retrieve and delete
-//        val result = client.getDel<TestData>(key)
-//        result shouldBe entity
-//
-//        // Verify key is deleted
-//        client.get<String>(key) shouldBe null
-//    }
-//
-//    @Test
-//    suspend fun `test getEx`() {
-//        val key = "testKeyGetEx"
-//        val ttlSeconds = 10
-//
-//        client.set(key, entity)
-//
-//        // Retrieve with EX option
-//        val result = client.getEx<TestData>(key, GetExOption.EX(ttlSeconds.seconds))
-//        result shouldBe entity
-//
-//        // Check remaining TTL is approximately set
-//        val ttl = client.ttl(key).shouldNotBeNull()
-//
-//        ttl shouldBeInRange (ttlSeconds - 2L)..ttlSeconds
-//    }
-//
-//    @Test
-//    suspend fun `test lcs`() {
-//        val key1 = "testKeyLcs1"
-//        val key2 = "testKeyLcs2"
-//        val value1 = "ABCD"
-//        val value2 = "ACDF"
-//
-//        client.set(key1, value1)
-//        client.set(key2, value2)
-//
-//        // Test Longest Common Substring
-//        val lcsResult = client.lcs<String>(key1, key2)
-//        lcsResult shouldBe "ACD"
-//    }
-//}
+package eu.vendeli.rethis.serde
+
+import eu.vendeli.rethis.ReThisTestCtx
+import eu.vendeli.rethis.command.serde.get
+import eu.vendeli.rethis.command.serde.mGet
+import eu.vendeli.rethis.command.serde.mSet
+import eu.vendeli.rethis.command.serde.set
+import eu.vendeli.rethis.utils.serdeModule
+import io.kotest.matchers.shouldBe
+
+class StringSerdeCommandsTest : ReThisTestCtx() {
+    private val entity = TestData("testValue", 2)
+    private val encodedEntity by lazy {
+        client.serdeModule().serialize(TestData.serializer(), entity)
+    }
+
+    @Test
+    suspend fun `test set and get`() {
+        val key = "testKeySet"
+
+        client.set(key, entity)
+
+        // Test retrieving as JSON string
+        val jsonResult = client.get<String>(key)
+        jsonResult shouldBe encodedEntity
+
+        // Test retrieving as deserialized object
+        val objResult = client.get<TestData>(key)
+        objResult shouldBe entity
+    }
+
+    @Test
+    suspend fun `test mSet and mGet`() {
+        val key1 = "testKeyM1"
+        val key2 = "testKeyM2"
+        val value2 = TestData(key2, 8)
+
+        client.mSet(key1 to entity, key2 to value2)
+
+        // Test multi-get as JSON strings
+        val jsonResults = client.mGet<String>(key1, key2)
+        jsonResults shouldBe listOf(
+            encodedEntity,
+            client.serdeModule().serialize(TestData.serializer(), value2),
+        )
+
+        // Test multi-get as objects
+        val objResults = client.mGet<TestData>(key1, key2)
+        objResults shouldBe listOf(entity, value2)
+    }
+}

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/TestData.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/TestData.kt
@@ -1,9 +1,12 @@
 package eu.vendeli.rethis.serde
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class TestData(
+    @SerialName("first")
     val field1: String,
+    @SerialName("second")
     val field2: Int,
 )


### PR DESCRIPTION
* Returned serialization support, with ability to use different serialization formats \
  (through configuration `serializationFormat` parameter, or by command function parameter), \
  supported commands `get`, `hget`, `hmget`, `hset`, `hvals`, `json.get`, `json.mget`, `json.set`, `mget`, `mset`, `set`.