### PR TITLE
Don't swallow or log CancellationException 

### DIFF
--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/utils/PubSubUtils.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/utils/PubSubUtils.kt
@@ -9,6 +9,7 @@ import eu.vendeli.rethis.types.coroutine.CoLocalConn
 import io.ktor.util.logging.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.Buffer
 import kotlinx.io.InternalIoApi
 
@@ -58,6 +59,8 @@ internal suspend fun ReThis.registerSubscription(
 
                 delay(1)
             }
+        } catch (e: CancellationException) {
+            throw e //Cancellation exceptions are normal part of coroutines, and should not be catched or spam logs
         } catch (e: Exception) {
             logger.error("Caught exception in $target channel handler", e)
             subscriptions.eventHandler?.onException(target, e)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other
  open [Pull Requests](https://github.com/vendelieu/re.this/pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

When unsubscribing subscriptions, the handlerjob is cancelled, but the CancellationException is then catched and logged. This is spamming my logs, and it's also best practice to purely rethrow CancellationExceptions without doing anything else with them and catch other exceptions seperately.

It's quite hard to write a test for this, but since the normal suite passes, I think it has no negative impact. Ofcourse, that's up to the maintainer to decide.