### PR TITLE
0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Re.this Changelog
 
+## 0.3.6
+
+* Added experimental distributed lock, try with `client.reDistributedLock`.
+* Added logging entries when response is substituted with default value in specific modes (transaction, pipeline).
+
 ## 0.3.5
 
 * Fixed ConcurrentModificationException in subscriptions (thanks to @peterdk).

--- a/buildSrc/src/main/kotlin/ConfigureKotlin.kt
+++ b/buildSrc/src/main/kotlin/ConfigureKotlin.kt
@@ -17,6 +17,7 @@ fun Project.configureKotlin(block: KotlinMultiplatformExtension.() -> Unit) {
                 "-Xwarning-level=NOTHING_TO_INLINE:disabled",
                 "-Xwarning-level=REDUNDANT_VISIBILITY_MODIFIER:disabled",
                 "-opt-in=eu.vendeli.rethis.annotations.ReThisInternal",
+                "-opt-in=eu.vendeli.rethis.annotations.ReThisExperimental",
                 "-Xannotation-default-target=param-property",
                 "-opt-in=kotlin.time.ExperimentalTime",
             )
@@ -30,7 +31,6 @@ fun Project.configureKotlin(block: KotlinMultiplatformExtension.() -> Unit) {
                         jvmTarget.set(JvmTarget.fromTarget("$jvmTargetVer"))
                         freeCompilerArgs.addAll(
                             "-Xjsr305=strict",
-                            "-opt-in=eu.vendeli.rethis.annotations.ReThisInternal",
                         )
                     }
                 }

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/annotations/ReThisExperimental.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/annotations/ReThisExperimental.kt
@@ -1,0 +1,23 @@
+package eu.vendeli.rethis.annotations
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This part of ReThis is experimental, signature or behavior that may be changed or even removed in the future, " +
+        "use at your own risk.",
+)
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.ANNOTATION_CLASS,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.LOCAL_VARIABLE,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER,
+    AnnotationTarget.TYPEALIAS,
+)
+annotation class ReThisExperimental

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Get.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Get.kt
@@ -4,6 +4,7 @@ import eu.vendeli.rethis.ReThis
 import eu.vendeli.rethis.command.string.get
 import eu.vendeli.rethis.shared.types.DataProcessingException
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import eu.vendeli.rethis.utils.isInTx
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -18,6 +19,10 @@ suspend fun <T> ReThis.get(
     serializer: KSerializer<T>,
     format: SerializationFormat = cfg.serializationFormat,
 ): T? {
+    if (isInTx()) {
+        logger.warn("Be aware that in transaction commands return `QUEUED`" +
+            " which is for type safety substituted with default value, so serde operations will fail")
+    }
     val s: String = get(key) ?: return null
     return try {
         format.deserialize(serializer, s)

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HGet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HGet.kt
@@ -4,6 +4,7 @@ import eu.vendeli.rethis.ReThis
 import eu.vendeli.rethis.command.hash.hGet
 import eu.vendeli.rethis.shared.types.DataProcessingException
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import eu.vendeli.rethis.utils.isInTx
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -18,6 +19,10 @@ suspend fun <T : Any> ReThis.hGet(
     serializer: KSerializer<T>,
     format: SerializationFormat = cfg.serializationFormat,
 ): T? {
+    if (isInTx()) {
+        logger.warn("Be aware that in transaction commands return `QUEUED`" +
+            " which is for type safety substituted with default value, so serde operations will fail")
+    }
     val raw: String = hGet(key, field) ?: return null
     return try {
         format.deserialize(serializer, raw)

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HMGet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HMGet.kt
@@ -4,6 +4,7 @@ import eu.vendeli.rethis.ReThis
 import eu.vendeli.rethis.command.hash.hMGet
 import eu.vendeli.rethis.shared.types.DataProcessingException
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import eu.vendeli.rethis.utils.isInTx
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -19,6 +20,10 @@ suspend fun <T : Any> ReThis.hMGet(
     serializer: KSerializer<T>,
     format: SerializationFormat = cfg.serializationFormat,
 ): List<T?> {
+    if (isInTx()) {
+        logger.warn("Be aware that in transaction commands return `QUEUED`" +
+            " which is for type safety substituted with default value, so serde operations will fail")
+    }
     val raw: List<String?> = hMGet(key, *field)
     return raw.map { string ->
         if (string == null) return@map null

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HSet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HSet.kt
@@ -4,6 +4,7 @@ import eu.vendeli.rethis.ReThis
 import eu.vendeli.rethis.command.hash.hSet
 import eu.vendeli.rethis.shared.request.common.FieldValue
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import eu.vendeli.rethis.utils.isInTx
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -18,6 +19,10 @@ suspend fun <T : Any> ReThis.hSet(
     serializer: KSerializer<T>,
     format: SerializationFormat = cfg.serializationFormat,
 ): Long {
+    if (isInTx()) {
+        logger.warn("Be aware that in transaction commands return `QUEUED`" +
+            " which is for type safety substituted with default value, so serde operations will fail")
+    }
     val serializedPairs = fieldValue.map { (f, v) ->
         FieldValue(f, format.serialize(serializer, v))
     }.toTypedArray()

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HVals.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/HVals.kt
@@ -4,6 +4,7 @@ import eu.vendeli.rethis.ReThis
 import eu.vendeli.rethis.command.hash.hVals
 import eu.vendeli.rethis.shared.types.DataProcessingException
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import eu.vendeli.rethis.utils.isInTx
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -16,6 +17,10 @@ suspend fun <T : Any> ReThis.hVals(
     serializer: KSerializer<T>,
     format: SerializationFormat = cfg.serializationFormat,
 ): List<T> {
+    if (isInTx()) {
+        logger.warn("Be aware that in transaction commands return `QUEUED`" +
+            " which is for type safety substituted with default value, so serde operations will fail")
+    }
     val raw: List<String> = hVals(key)
     return raw.map { string ->
         try {

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonGet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonGet.kt
@@ -5,6 +5,7 @@ import eu.vendeli.rethis.command.json.jsonGet
 import eu.vendeli.rethis.shared.request.json.JsonGetOption
 import eu.vendeli.rethis.shared.types.DataProcessingException
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import eu.vendeli.rethis.utils.isInTx
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -19,6 +20,10 @@ suspend fun <T : Any> ReThis.jsonGet(
     serializer: KSerializer<T>,
     format: SerializationFormat = cfg.serializationFormat,
 ): T? {
+    if (isInTx()) {
+        logger.warn("Be aware that in transaction commands return `QUEUED`" +
+            " which is for type safety substituted with default value, so serde operations will fail")
+    }
     val raw: String = jsonGet(key = key, options = options) ?: return null
     return try {
         format.deserialize(serializer, raw)

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonMGet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonMGet.kt
@@ -4,6 +4,7 @@ import eu.vendeli.rethis.ReThis
 import eu.vendeli.rethis.command.json.jsonMGet
 import eu.vendeli.rethis.shared.types.DataProcessingException
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import eu.vendeli.rethis.utils.isInTx
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -18,6 +19,10 @@ suspend fun <T : Any> ReThis.jsonMGet(
     serializer: KSerializer<T>,
     format: SerializationFormat = cfg.serializationFormat,
 ): List<T?> {
+    if (isInTx()) {
+        logger.warn("Be aware that in transaction commands return `QUEUED`" +
+            " which is for type safety substituted with default value, so serde operations will fail")
+    }
     val raw: List<String?> = jsonMGet(path, *key)
     return raw.map { string ->
         if (string == null) return@map null

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonSet.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/JsonSet.kt
@@ -5,6 +5,7 @@ import eu.vendeli.rethis.command.json.jsonSet
 import eu.vendeli.rethis.shared.request.string.UpsertMode
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
 import eu.vendeli.rethis.utils.JSON_DEFAULT_PATH
+import eu.vendeli.rethis.utils.isInTx
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -23,6 +24,10 @@ suspend fun <T : Any> ReThis.jsonSet(
     upsertMode: UpsertMode? = null,
     format: SerializationFormat = cfg.serializationFormat,
 ): String {
+    if (isInTx()) {
+        logger.warn("Be aware that in transaction commands return `QUEUED`" +
+            " which is for type safety substituted with default value, so serde operations will fail")
+    }
     val serialized = format.serialize(serializer, value)
     return jsonSet(key, serialized, path, upsertMode)
 }

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Mget.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Mget.kt
@@ -4,6 +4,7 @@ import eu.vendeli.rethis.ReThis
 import eu.vendeli.rethis.command.string.mGet
 import eu.vendeli.rethis.shared.types.DataProcessingException
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import eu.vendeli.rethis.utils.isInTx
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -16,6 +17,10 @@ suspend fun <T : Any> ReThis.mGet(
     serializer: KSerializer<T>,
     format: SerializationFormat = cfg.serializationFormat,
 ): List<T?> {
+    if (isInTx()) {
+        logger.warn("Be aware that in transaction commands return `QUEUED`" +
+            " which is for type safety substituted with default value, so serde operations will fail")
+    }
     val raw: List<String?> = mGet(*key)
     return raw.map { string ->
         if (string == null) return@map null

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Mset.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Mset.kt
@@ -4,6 +4,7 @@ import eu.vendeli.rethis.ReThis
 import eu.vendeli.rethis.command.string.mSet
 import eu.vendeli.rethis.shared.request.string.KeyValue
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import eu.vendeli.rethis.utils.isInTx
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -16,6 +17,10 @@ suspend fun <T : Any> ReThis.mSet(
     serializer: KSerializer<T>,
     format: SerializationFormat = cfg.serializationFormat,
 ): Boolean {
+    if (isInTx()) {
+        logger.warn("Be aware that in transaction commands return `QUEUED`" +
+            " which is for type safety substituted with default value, so serde operations will fail")
+    }
     val serializedPairs = kvPair.map { (k, v) ->
         KeyValue(k, format.serialize(serializer, v))
     }.toTypedArray()

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Set.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/serde/Set.kt
@@ -4,6 +4,7 @@ import eu.vendeli.rethis.ReThis
 import eu.vendeli.rethis.command.string.set
 import eu.vendeli.rethis.shared.request.string.SetOption
 import eu.vendeli.rethis.types.interfaces.SerializationFormat
+import eu.vendeli.rethis.utils.isInTx
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -22,6 +23,10 @@ suspend fun <T> ReThis.`set`(
     vararg options: SetOption,
     serializationFormat: SerializationFormat = cfg.serializationFormat,
 ): String? {
+    if (isInTx()) {
+        logger.warn("Be aware that in transaction commands return `QUEUED`" +
+            " which is for type safety substituted with default value, so serde operations will fail")
+    }
     val value = serializationFormat.serialize(serializer, value)
     return set(key, value, *options)
 }

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/topology/TopologyManager.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/topology/TopologyManager.kt
@@ -29,6 +29,7 @@ internal suspend inline fun TopologyManager.handle(request: CommandRequest): Buf
         when {
             coPipeline != null -> {
                 coPipeline.pipelined.add(request)
+                warnOfSubstitution(cfg)
                 EMPTY_BUFFER
             }
 
@@ -40,10 +41,19 @@ internal suspend inline fun TopologyManager.handle(request: CommandRequest): Buf
                         RespCode.BULK_ERROR -> BulkErrorDecoder.decode(it, cfg.charset, code)
                         else -> it.writeByte(peekedByte)
                     }
-                }.takeIf { !coLocalConn.isTx } ?: EMPTY_BUFFER
+                }.takeIf { !coLocalConn.isTx } ?: run {
+                    warnOfSubstitution(cfg)
+                    EMPTY_BUFFER
+                }
             // return empty buffer if transaction (to not break response contract since transaction return QUEUED)
 
             else -> route(request).execute(request)
         }
     }.getOrElse { handleFailure(request, it) }
+}
+
+private inline fun warnOfSubstitution(cfg: ReThisConfiguration) {
+    cfg.loggerFactory.get("eu.vendeli.rethis.topology.TopologyManager")
+        .debug("Response substituted to EMPTY_BUFFER " +
+            "and will be handled as default response since it been executed in special construction")
 }

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/topology/TopologyManager.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/topology/TopologyManager.kt
@@ -10,6 +10,7 @@ import eu.vendeli.rethis.shared.utils.EMPTY_BUFFER
 import eu.vendeli.rethis.types.coroutine.CoLocalConn
 import eu.vendeli.rethis.types.coroutine.CoPipelineCtx
 import eu.vendeli.rethis.utils.withRetry
+import io.ktor.util.logging.debug
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.io.Buffer
 
@@ -54,6 +55,8 @@ internal suspend inline fun TopologyManager.handle(request: CommandRequest): Buf
 
 private inline fun warnOfSubstitution(cfg: ReThisConfiguration) {
     cfg.loggerFactory.get("eu.vendeli.rethis.topology.TopologyManager")
-        .debug("Response substituted to EMPTY_BUFFER " +
-            "and will be handled as default response since it been executed in special construction")
+        .debug {
+            "Response substituted to EMPTY_BUFFER " +
+            "and will be handled as default response since it been executed in special construction"
+        }
 }

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/types/common/ReThisReentrantLock.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/types/common/ReThisReentrantLock.kt
@@ -1,0 +1,363 @@
+package eu.vendeli.rethis.types.common
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.command.generic.pTtl
+import eu.vendeli.rethis.command.scripting.eval
+import eu.vendeli.rethis.shared.types.LockLostException
+import eu.vendeli.rethis.shared.utils.unwrap
+import eu.vendeli.rethis.types.interfaces.ReDistributedLock
+import kotlinx.coroutines.*
+import kotlin.concurrent.atomics.*
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
+import kotlin.time.TimeSource
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Implementation notes:
+ * - Redis representation is a HASH at `key` with fields:
+ *     - owner: string (token)
+ *     - count: integer
+ *     - ver: 1 (format version)
+ * - Scripts return codes (by convention):
+ *     1 -> success
+ *     0 -> absent / not-acquired (for acquire: means someone else holds it)
+ *    -1 -> token mismatch (caller is not owner)
+ *    -2 -> corrupted state (malformed fields)
+ *
+ * Watchdog
+ * - Refreshes TTL using REFRESH_SCRIPT (atomic: check owner then pexpire)
+ * - Runs on a separate SupervisorScope to avoid interfering with caller coroutine
+ */
+@OptIn(ExperimentalAtomicApi::class)
+internal class ReThisReentrantLock(
+    private val client: ReThis,
+    private val key: String,
+    private val referenceJob: Job,
+    private val defaultLeaseMs: Long = 30_000L,
+    private val backoffBaseMs: Long = 50L,
+    private val backoffCapMs: Long = 1000L,
+) : ReDistributedLock {
+
+    @OptIn(ExperimentalUuidApi::class)
+    private val instanceId = "inst:${Uuid.random()}"
+
+    // stable owner token derived from referenceJob in-process; null when not currently owning
+    private val ownerIdLocal = AtomicReference<String?>(deriveOwnerId(referenceJob))
+
+    // local fast-path counter (keeps quick reentrant checks) — authoritative counter lives in Redis
+    private val localDepth = AtomicInt(0)
+
+    // Watchdog scope + job
+    private val watchdogScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val watchdogJob = AtomicReference<Job?>(null)
+
+    // ------------------------
+    // Public API
+    // ------------------------
+
+    override suspend fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean {
+        currentCoroutineContext().ensureActive()
+        val job = currentCoroutineContext()[Job] ?: error("No Job in context")
+
+        val waitMs = waitTime.toLong(DurationUnit.MILLISECONDS).coerceAtLeast(0)
+        val leaseMs = leaseTime.toLong(DurationUnit.MILLISECONDS).let { if (it > 0) it else defaultLeaseMs }
+        val start = TimeSource.Monotonic.markNow()
+
+        // Fast-path when we already believe we are owner locally
+        if (isSameOwner(job) && localDepth.load() > 0) {
+            val token = ownerIdLocal.load() ?: ""
+            val r = acquireScript(token, leaseMs)
+            when (r) {
+                1 -> {
+                    localDepth.incrementAndFetch()
+                    // ensure TTL is healthy
+                    verifyTTL(leaseMs)
+                    return true
+                }
+
+                0 -> { /* someone else owns it now — fall through to acquisition loop */
+                }
+
+                -1 -> throw LockLostException("Token mismatch during optimistic reenter for key=$key")
+                -2 -> throw LockLostException("Corrupted lock state during optimistic reenter for key=$key")
+            }
+        }
+
+        var lastBackoff = backoffBaseMs
+        val token = makeTokenForJob(job)
+
+        while (true) {
+            currentCoroutineContext().ensureActive()
+
+            val r = acquireScript(token, leaseMs)
+            when (r) {
+                1 -> {
+                    ownerIdLocal.store(token)
+                    localDepth.incrementAndFetch()
+                    // start watchdog only on the initial ownership (depth==1)
+                    startWatchdog(token, leaseMs)
+                    verifyTTL(leaseMs)
+                    return true
+                }
+
+                0 -> { /* someone else holds it; retry or return depending on wait */
+                }
+
+                -1 -> {
+                    throw LockLostException("Lock currently held by another owner for key=$key")
+                }
+
+                -2 -> {
+                    throw LockLostException("Corrupted lock state for key=$key")
+                }
+            }
+
+            if (waitMs == 0L || start.elapsedNow().inWholeMilliseconds >= waitMs) return false
+
+            val delayMs = decorrelatedExponentialJitter(lastBackoff).coerceAtMost(backoffCapMs)
+            lastBackoff = delayMs
+            delay(delayMs)
+        }
+    }
+
+    override suspend fun lock(leaseTime: Duration) {
+        val leaseMs = leaseTime.toLong(DurationUnit.MILLISECONDS).let { if (it > 0) it else defaultLeaseMs }
+        while (true) {
+            currentCoroutineContext().ensureActive()
+            if (tryLock(Duration.ZERO, leaseMs.milliseconds)) return
+            delay(decorrelatedExponentialJitter(backoffBaseMs))
+        }
+    }
+
+    override suspend fun unlock(): Boolean {
+        currentCoroutineContext().ensureActive()
+        currentCoroutineContext()[Job] ?: error("No Job in context")
+
+        val token = ownerIdLocal.load() ?: return false
+
+        // decrement local depth
+        val newLocal = localDepth.updateAndFetch { cur -> if (cur > 0) cur - 1 else 0 }
+
+        val isFinal = newLocal == 0
+        val r = releaseScript(token, if (isFinal) defaultLeaseMs else defaultLeaseMs)
+
+        when (r) {
+            1 -> {
+                if (isFinal) {
+                    stopWatchdog()
+                    ownerIdLocal.store(null)
+                    localDepth.store(0)
+                }
+                return true
+            }
+
+            0 -> throw LockLostException("Lock already missing/expired for key=$key during unlock")
+            -1 -> throw LockLostException("Unlock attempted by non-owner for key=$key")
+            -2 -> throw LockLostException("Corrupted lock state for key=$key during unlock")
+            else -> throw IllegalStateException("Unexpected unlock script response: $r for key=$key")
+        }
+    }
+
+    // ------------------------
+    // Watchdog
+    // ------------------------
+
+    private fun startWatchdog(token: String, leaseMs: Long) {
+        stopWatchdog()
+        watchdogJob.compareAndSet(
+            null,
+            watchdogScope.launch {
+                val base = (leaseMs / 3).coerceAtLeast(50L)
+                while (isActive) {
+                    // add small jitter
+                    val jitter = Random.nextLong(0, base / 5 + 1)
+                    delay(base + jitter)
+                    try {
+                        val r = refreshScript(token, leaseMs)
+                        if (r != 1) {
+                            // any non-success indicates the lock is lost or corrupted
+                            throw LockLostException("Watchdog failed to refresh key=$key response=$r")
+                        }
+                    } catch (t: Throwable) {
+                        // escalate — cancel watchdog and surface exception asynchronously
+                        stopWatchdog()
+                        // We cannot throw from here to caller; instead, best-effort: log and cancel owner
+                        // For library: consider invoking a user-provided callback here
+                        // Re-throw using coroutine cancellation to stop watchdog
+                        cancel("Watchdog stopped due to error: ${t.message}")
+                    }
+                }
+            },
+        )
+    }
+
+    private fun stopWatchdog() {
+        watchdogJob.exchange(null)?.cancel()
+    }
+
+    // ------------------------
+    // Helpers
+    // ------------------------
+
+    private fun isSameOwner(job: Job): Boolean = job.isRelativeTo(referenceJob) && ownerIdLocal.load() != null
+
+    @OptIn(ExperimentalUuidApi::class)
+    private fun makeTokenForJob(job: Job): String {
+        val ownerPart = if (job.isRelativeTo(referenceJob)) deriveOwnerId(referenceJob) else deriveOwnerId(job)
+        return "$instanceId:$ownerPart:${Uuid.random()}"
+    }
+
+    private fun deriveOwnerId(job: Job): String = "job_${job.hashCode()}_${Random.nextInt(0xFFFF)}"
+
+    private fun decorrelatedExponentialJitter(prev: Long): Long {
+        val previous = prev * 3
+        val newDelay = Random.nextLong(backoffBaseMs, previous)
+        return newDelay.coerceAtMost(backoffCapMs)
+    }
+
+    private suspend fun verifyTTL(leaseMs: Long) = runCatching {
+        val ttl = client.pTtl(key)
+        if (ttl < leaseMs / 4) {
+            throw LockLostException("Redis TTL too low for key=$key ($ttl ms) after acquire; lease=$leaseMs")
+        }
+    }.onFailure { t ->
+        throw LockLostException("PTTL verification failed for key=$key: ${t.message}")
+    }
+
+    // ------------------------
+    // Redis script wrappers
+    // ------------------------
+
+    private suspend fun acquireScript(token: String, leaseMs: Long): Int =
+        runCatching {
+            val r = client.eval(ACQUIRE_SCRIPT, key = arrayOf(key), arg = listOf(token, leaseMs.toString()))
+            return r.unwrap<Long?>()?.toInt() ?: -2
+        }.getOrElse { -2 }
+
+    private suspend fun releaseScript(token: String, leaseMs: Long): Int =
+        runCatching {
+            val r = client.eval(RELEASE_SCRIPT, key = arrayOf(key), arg = listOf(token, leaseMs.toString()))
+            return r.unwrap<Long?>()?.toInt() ?: -2
+        }.getOrElse { -2 }
+
+
+    private suspend fun refreshScript(token: String, leaseMs: Long): Int =
+        runCatching {
+            val r = client.eval(REFRESH_SCRIPT, key = arrayOf(key), arg = listOf(token, leaseMs.toString()))
+            return r.unwrap<Long?>()?.toInt() ?: -2
+        }.getOrElse { -2 }
+
+    companion object {
+        /**
+         *             -- ACQUIRE_SCRIPT
+         *             -- ARGV[1] = token
+         *             -- ARGV[2] = lease (ms)
+         *             local key = KEYS[1]
+         *             local token = ARGV[1]
+         *             local lease = tonumber(ARGV[2]) or 0
+         *
+         *             -- fetch fields safely
+         *             local owner = redis.call('HGET', key, 'owner')
+         *             local count = redis.call('HGET', key, 'count')
+         *             local ver = redis.call('HGET', key, 'ver')
+         *
+         *             if count and type(count) == 'string' then count = tonumber(count) end
+         *             if ver and type(ver) == 'string' then ver = tonumber(ver) end
+         *
+         *             -- absent lock => initialize
+         *             if not owner then
+         *               redis.call('HSET', key, 'owner', token)
+         *               redis.call('HSET', key, 'count', 1)
+         *               redis.call('HSET', key, 'ver', 1)
+         *               redis.call('PEXPIRE', key, lease)
+         *               return 1
+         *             end
+         *
+         *             -- corrupted: count not number or ver mismatch
+         *             if (not count) or (ver ~= 1) then
+         *               return -2
+         *             end
+         *
+         *             -- reentrant by same owner
+         *             if owner == token then
+         *               local newc = count + 1
+         *               redis.call('HSET', key, 'count', newc)
+         *               redis.call('PEXPIRE', key, lease)
+         *               return 1
+         *             end
+         *
+         *             -- owned by someone else
+         *             return 0
+         */
+        private const val ACQUIRE_SCRIPT =
+            "local key=KEYS[1];local token=ARGV[1];local lease=tonumber(ARGV[2])or 0;local owner=redis.call('HGET',key,'owner');local count=redis.call('HGET',key,'count');local ver=redis.call('HGET',key,'ver');if count and type(count)=='string'then count=tonumber(count)end;if ver and type(ver)=='string'then ver=tonumber(ver)end;if not owner then redis.call('HSET',key,'owner',token);redis.call('HSET',key,'count',1);redis.call('HSET',key,'ver',1);redis.call('PEXPIRE',key,lease);return 1 end;if(not count)or(ver~=1)then return -2 end;if owner==token then local newc=count+1;redis.call('HSET',key,'count',newc);redis.call('PEXPIRE',key,lease);return 1 end;return 0"
+
+        /**
+         *             -- RELEASE_SCRIPT
+         *             -- ARGV[1] = token
+         *             -- ARGV[2] = lease (ms) — used only if decrementing count
+         *             local key = KEYS[1]
+         *             local token = ARGV[1]
+         *             local lease = tonumber(ARGV[2]) or 0
+         *
+         *             local owner = redis.call('HGET', key, 'owner')
+         *             if not owner then return 0 end
+         *             local count = redis.call('HGET', key, 'count')
+         *             local ver = redis.call('HGET', key, 'ver')
+         *
+         *             if type(count) == 'string' then count = tonumber(count) end
+         *             if type(ver) == 'string' then ver = tonumber(ver) end
+         *
+         *             if not count or ver ~= 1 then return -2 end
+         *             if owner ~= token then return -1 end
+         *
+         *             local newc = count - 1
+         *             if newc > 0 then
+         *               redis.call('HSET', key, 'count', newc)
+         *               redis.call('PEXPIRE', key, lease)
+         *               return 1
+         *             else
+         *               redis.call('DEL', key)
+         *               return 1
+         *             end
+         */
+        private const val RELEASE_SCRIPT =
+            "local key=KEYS[1];local token=ARGV[1];local lease=tonumber(ARGV[2])or 0;local owner=redis.call('HGET',key,'owner');if not owner then return 0 end;local count=redis.call('HGET',key,'count');local ver=redis.call('HGET',key,'ver');if type(count)=='string' then count=tonumber(count) end;if type(ver)=='string' then ver=tonumber(ver) end;if not count or ver~=1 then return -2 end;if owner~=token then return -1 end;local newc=count-1;if newc>0 then redis.call('HSET',key,'count',newc);redis.call('PEXPIRE',key,lease);return 1 else redis.call('DEL',key);return 1 end"
+
+        /**
+         *             -- REFRESH_SCRIPT
+         *             -- ARGV[1] = token
+         *             -- ARGV[2] = lease (ms)
+         *             local key = KEYS[1]
+         *             local token = ARGV[1]
+         *             local lease = tonumber(ARGV[2]) or 0
+         *
+         *             local owner = redis.call('HGET', key, 'owner')
+         *             if not owner then return 0 end
+         *             if owner ~= token then return -1 end
+         *             -- refresh TTL
+         *             redis.call('PEXPIRE', key, lease)
+         *             return 1
+         */
+        private const val REFRESH_SCRIPT =
+            "local key=KEYS[1];local token=ARGV[1];local lease=tonumber(ARGV[2])or 0;local owner=redis.call('HGET',key,'owner');if not owner then return 0 end;if owner~=token then return -1 end;redis.call('PEXPIRE',key,lease);return 1"
+    }
+}
+
+/**
+ * Checks whether [this] job is the same as [referenceJob] or an ancestor of it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+private fun Job.isRelativeTo(referenceJob: Job): Boolean {
+    if (this === referenceJob) return true
+    var current: Job? = referenceJob
+    while (current != null) {
+        if (current === this) return true
+        current = current.parent
+    }
+    return false
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/types/interfaces/ReDistributedLock.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/types/interfaces/ReDistributedLock.kt
@@ -1,0 +1,16 @@
+package eu.vendeli.rethis.types.interfaces
+
+import kotlin.time.Duration
+
+/**
+ * Distributed reentrant lock interface.
+ */
+interface ReDistributedLock {
+    suspend fun tryLock(
+        waitTime: Duration = Duration.ZERO,
+        leaseTime: Duration = Duration.ZERO,
+    ): Boolean
+
+    suspend fun lock(leaseTime: Duration = Duration.ZERO)
+    suspend fun unlock(): Boolean
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/utils/CommonUtils.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/utils/CommonUtils.kt
@@ -7,11 +7,13 @@ import eu.vendeli.rethis.shared.response.common.HostAndPort
 import eu.vendeli.rethis.shared.types.RespCode
 import eu.vendeli.rethis.shared.utils.EMPTY_BUFFER
 import eu.vendeli.rethis.types.common.Address
+import eu.vendeli.rethis.types.coroutine.CoLocalConn
 import io.ktor.network.sockets.*
 import io.ktor.util.logging.*
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.io.Buffer
 
@@ -54,3 +56,8 @@ internal suspend inline fun <T> withRetry(
 internal inline fun HostAndPort.toAddress(): Address = Address(host, port)
 internal inline fun Address.toHostAndPort(): HostAndPort? =
     if (socket is InetSocketAddress) HostAndPort(socket.hostname, socket.port) else null
+
+internal suspend fun isInTx(): Boolean {
+    val coLocalCon = currentCoroutineContext()[CoLocalConn]
+    return coLocalCon != null && coLocalCon.isTx
+}

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/utils/ReDistributedLock.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/utils/ReDistributedLock.kt
@@ -1,0 +1,42 @@
+package eu.vendeli.rethis.utils
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.annotations.ReThisExperimental
+import eu.vendeli.rethis.types.common.ReThisReentrantLock
+import eu.vendeli.rethis.types.interfaces.ReDistributedLock
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+// Structured helper: guarantees unlock in finally, safe for coroutine cancellation.
+suspend inline fun <T> ReDistributedLock.withLock(
+    leaseTime: Duration = Duration.ZERO,
+    crossinline block: suspend () -> T,
+): T {
+    lock(leaseTime)
+    try {
+        return block()
+    } finally {
+        withContext(NonCancellable) { unlock() }
+    }
+}
+
+@ReThisExperimental
+suspend fun ReThis.reDistributedLock(
+    key: String,
+    waitTime: Duration = 50.milliseconds,
+    leaseTime: Duration = 30.seconds,
+): ReDistributedLock {
+    val referenceJob = currentCoroutineContext()[Job] ?: error("No Job in context")
+    return ReThisReentrantLock(
+        client = this,
+        key = key,
+        referenceJob = referenceJob,
+        defaultLeaseMs = leaseTime.inWholeMilliseconds,
+        backoffBaseMs = waitTime.inWholeMilliseconds,
+    )
+}

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/PipeliningTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/PipeliningTest.kt
@@ -39,7 +39,8 @@ class PipeliningTest : ReThisTestCtx() {
                     }.also {
                         println("------$it")
                     }
-            }.shouldNotBeNull().run {
+            }.shouldNotBeNull()
+            .run {
                 this shouldHaveSize 2
                 first() shouldBe PlainString("OK")
                 last() shouldBe BulkString("testv1")
@@ -94,7 +95,8 @@ class PipeliningTest : ReThisTestCtx() {
                 client.transaction {
                     get("test1")
                 }
-            }.shouldNotBeNull().run {
+            }.shouldNotBeNull()
+            .run {
                 shouldHaveSize(2)
                 first() shouldBe PlainString("OK")
                 last() shouldBe BulkString("testv1")

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/ReThisTestCtx.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/ReThisTestCtx.kt
@@ -33,6 +33,6 @@ abstract class ReThisTestCtx(
     }
 
     protected fun createClient(
-        cfg: StandaloneConfiguration.() -> Unit = {}
+        cfg: StandaloneConfiguration.() -> Unit = {},
     ): ReThis = ReThis(redis.host, redis.firstMappedPort, configurator = cfg)
 }

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/ReThisTestCtx.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/ReThisTestCtx.kt
@@ -3,6 +3,7 @@ package eu.vendeli.rethis
 import com.redis.testcontainers.RedisContainer
 import eu.vendeli.rethis.codecs.connection.PingCommandCodec
 import eu.vendeli.rethis.configuration.ReThisConfiguration
+import eu.vendeli.rethis.configuration.StandaloneConfiguration
 import io.kotest.core.spec.style.AnnotationSpec
 import org.testcontainers.utility.DockerImageName
 import kotlin.time.Clock
@@ -31,5 +32,7 @@ abstract class ReThisTestCtx(
         reThis = new
     }
 
-    protected fun createClient(): ReThis = ReThis(redis.host, redis.firstMappedPort)
+    protected fun createClient(
+        cfg: StandaloneConfiguration.() -> Unit = {}
+    ): ReThis = ReThis(redis.host, redis.firstMappedPort, configurator = cfg)
 }

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/GeoCommandTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/GeoCommandTest.kt
@@ -66,9 +66,9 @@ class GeoCommandTest : ReThisTestCtx() {
                         listOf(
                             BulkString("13.36138933897018433"),
                             BulkString("38.11555639549629859"),
-                        )
-                    )
-                )
+                        ),
+                    ),
+                ),
             ),
             RArray(
                 listOf(
@@ -79,12 +79,11 @@ class GeoCommandTest : ReThisTestCtx() {
                         listOf(
                             BulkString("12.7584877610206604"),
                             BulkString("38.78813451624225195"),
-                        )
-                    )
-                )
-            )
+                        ),
+                    ),
+                ),
+            ),
         )
-
     }
 
     @Test

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/HashCommandTest2.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/HashCommandTest2.kt
@@ -46,7 +46,6 @@ class HashCommandTest2 : ReThisTestCtx() {
         val allFields = listOf("field1", "field2", "field3")
         val allValues = listOf("value1", "value2", "value3")
 
-
         fields.first() shouldBeIn allFields
         fields.get(1) shouldBeIn allValues
         fields.get(2) shouldBeIn allFields

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/JsonCommandTest2.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/JsonCommandTest2.kt
@@ -29,7 +29,7 @@ class JsonCommandTest2 : ReThisTestCtx(true) {
     @Test
     suspend fun `test JSON_NUMMULTBY command`() {
         client.jsonSet("testKey16", "{\"a\":\"b\",\"b\":[{\"a\":2}, {\"a\":5}, {\"a\":\"c\"}]}", ".")
-        client.jsonNumMultBy("testKey16", "..a", 2.0) shouldBe BulkString(value="10.0")
+        client.jsonNumMultBy("testKey16", "..a", 2.0) shouldBe BulkString(value = "10.0")
     }
 
     @Test
@@ -42,7 +42,8 @@ class JsonCommandTest2 : ReThisTestCtx(true) {
     suspend fun `test JSON_OBJLEN command`() {
         client.jsonSet("testKey18", "{\"a\":[3], \"nested\": {\"a\": {\"b\":2, \"c\": 1}}}", ".")
         client.jsonObjLen("testKey18", "$..a").shouldBeTypeOf<RArray>().value shouldBe listOf(
-            RType.Null, Int64(2)
+            RType.Null,
+            Int64(2),
         )
     }
 
@@ -84,6 +85,6 @@ class JsonCommandTest2 : ReThisTestCtx(true) {
     @Test
     suspend fun `test JSON_TYPE command`() {
         client.jsonSet("testKey24", "[1, 2, 3]", ".")
-        client.jsonType("testKey24", ".") shouldBe BulkString(value="array")
+        client.jsonType("testKey24", ".") shouldBe BulkString(value = "array")
     }
 }

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/PubSubCommandTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/PubSubCommandTest.kt
@@ -59,7 +59,7 @@ class PubSubCommandTest : ReThisTestCtx() {
     }
 
     @Test
-    suspend fun `test PUNSUBSCRIBE command`()  = shouldNotThrowAny {
+    suspend fun `test PUNSUBSCRIBE command`() = shouldNotThrowAny {
         client.pUnsubscribe("testPattern")
     }
 
@@ -74,7 +74,7 @@ class PubSubCommandTest : ReThisTestCtx() {
     }
 
     @Test
-    suspend fun `test UNSUBSCRIBE command`()  = shouldNotThrowAny {
+    suspend fun `test UNSUBSCRIBE command`() = shouldNotThrowAny {
         client.unsubscribe("testPattern")
     }
 

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/SortedSetCommandTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/SortedSetCommandTest.kt
@@ -55,7 +55,12 @@ class SortedSetCommandTest : ReThisTestCtx() {
     suspend fun `test ZPOPMIN command`() {
         client.zAdd("testSet27", ZMember("testValue27", 1.0))
 
-        client.zPopMin("testSet27").shouldNotBeEmpty().first().shouldBeTypeOf<BulkString>().value shouldBe "testValue27"
+        client
+            .zPopMin("testSet27")
+            .shouldNotBeEmpty()
+            .first()
+            .shouldBeTypeOf<BulkString>()
+            .value shouldBe "testValue27"
     }
 
     @Test

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/StreamCommandsTest2.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/StreamCommandsTest2.kt
@@ -16,7 +16,8 @@ class StreamCommandsTest2 : ReThisTestCtx() {
         val groupName = "mygroup-1"
         client.xGroupCreate(streamName, groupName, XId.Id("0"), mkstream = true)
         val id = client.xAdd(
-            streamName, idSelector = XAddOption.Asterisk,
+            streamName,
+            idSelector = XAddOption.Asterisk,
             data = arrayOf(
                 FieldValue(
                     "field1",

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/StringCommandTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/StringCommandTest.kt
@@ -27,10 +27,11 @@ class StringCommandTest : ReThisTestCtx() {
 
     @Test
     suspend fun `test MSETNX command`() {
-        client.mSetNx(
-            KeyValue("testKey5", "testValue5"),
-            KeyValue("testKey6", "testValue6"),
-        ).shouldBeTrue()
+        client
+            .mSetNx(
+                KeyValue("testKey5", "testValue5"),
+                KeyValue("testKey6", "testValue6"),
+            ).shouldBeTrue()
     }
 
     @Test

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/TransactionCommandTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/TransactionCommandTest.kt
@@ -36,21 +36,29 @@ class TransactionCommandTest : ReThisTestCtx() {
         val cProvider = connectionProvider()
         val conn = cProvider.borrowConnection()
 
-        conn.doRequest(MultiCommandCodec.encode(Charsets.UTF_8).buffer).readResponseWrapped(charset = Charsets.UTF_8)
-            .isOk().shouldBeTrue()
+        conn
+            .doRequest(MultiCommandCodec.encode(Charsets.UTF_8).buffer)
+            .readResponseWrapped(charset = Charsets.UTF_8)
+            .isOk()
+            .shouldBeTrue()
 
-        conn.doRequest(
-            SetCommandCodec.encode(Charsets.UTF_8, "test1", "testv1").buffer,
-        ).readResponseWrapped(Charsets.UTF_8).shouldBe(PlainString("QUEUED"))
+        conn
+            .doRequest(
+                SetCommandCodec.encode(Charsets.UTF_8, "test1", "testv1").buffer,
+            ).readResponseWrapped(Charsets.UTF_8)
+            .shouldBe(PlainString("QUEUED"))
 
-        conn.doRequest(
-            SetCommandCodec.encode(Charsets.UTF_8, "test2", "testv2").buffer,
-        ).readResponseWrapped(Charsets.UTF_8).shouldBe(PlainString("QUEUED"))
+        conn
+            .doRequest(
+                SetCommandCodec.encode(Charsets.UTF_8, "test2", "testv2").buffer,
+            ).readResponseWrapped(Charsets.UTF_8)
+            .shouldBe(PlainString("QUEUED"))
 
-
-        conn.doRequest(
-            ExecCommandCodec.encode(Charsets.UTF_8).buffer,
-        ).readResponseWrapped(Charsets.UTF_8).shouldBeTypeOf<RArray>() shouldBe RArray(
+        conn
+            .doRequest(
+                ExecCommandCodec.encode(Charsets.UTF_8).buffer,
+            ).readResponseWrapped(Charsets.UTF_8)
+            .shouldBeTypeOf<RArray>() shouldBe RArray(
             listOf(
                 PlainString("OK"),
                 PlainString("OK"),
@@ -79,7 +87,8 @@ class TransactionCommandTest : ReThisTestCtx() {
                 client.multi()
                 client.set("testKey1", "testVal1")
                 client.set("testKey2", "testVal2")
-                client.execute(listOf("GETBIT").toRESPBuffer())
+                client
+                    .execute(listOf("GETBIT").toRESPBuffer())
                     .readResponseWrapped()
                     .shouldBeTypeOf<RType.Error>()
                     .exception

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/core/SubscriptionManagerTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/core/SubscriptionManagerTest.kt
@@ -7,7 +7,6 @@ import eu.vendeli.rethis.types.interfaces.SubscriptionHandler
 import org.junit.jupiter.api.assertDoesNotThrow
 
 class SubscriptionManagerTest : ReThisTestCtx() {
-
     @Test
     fun `Given pattern subscriptions, When unsubscribing all, Then no exception is thrown`() {
         // Given

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/HashSerdeCommandsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/HashSerdeCommandsTest.kt
@@ -30,8 +30,6 @@ class HashSerdeCommandsTest : ReThisTestCtx() {
         val serializedResult = client.hGet(key, field, serializer)
         serializedResult shouldBe entity
     }
-    
-    
 
     @Test
     suspend fun `test hVals`() {

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/JsonSerdeCommandsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/serde/JsonSerdeCommandsTest.kt
@@ -75,11 +75,13 @@ class JsonSerdeCommandsTest : ReThisTestCtx(true) {
         client.jsonSet(key, data)
 
         // Pop from nested array
-        client.jsonArrPop(key, "$.users")
+        client
+            .jsonArrPop(key, "$.users")
             .shouldBeTypeOf<RArray>()
             .value
             .first()
-            .shouldBeTypeOf<BulkString>().let {
+            .shouldBeTypeOf<BulkString>()
+            .let {
                 client.serdeModule().deserialize(User.serializer(), it.unwrap<String>()!!)
             } shouldBe User(5, "Eve")
         client.jsonGet<NestedUserList>(key) shouldBe NestedUserList(

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/utils/RTypeResponseTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/utils/RTypeResponseTest.kt
@@ -1,28 +1,28 @@
-//package eu.vendeli.rethis.utils
+// package eu.vendeli.rethis.utils
 //
-//import com.ionspin.kotlin.bignum.integer.toBigInteger
-//import eu.vendeli.rethis.ReThisTestCtx
-//import eu.vendeli.rethis.shared.types.BigNumber
-//import eu.vendeli.rethis.shared.types.Bool
-//import eu.vendeli.rethis.shared.types.BulkString
-//import eu.vendeli.rethis.shared.types.F64
-//import eu.vendeli.rethis.shared.types.Int64
-//import eu.vendeli.rethis.shared.types.PlainString
-//import eu.vendeli.rethis.shared.types.Push
-//import eu.vendeli.rethis.shared.types.RArray
-//import eu.vendeli.rethis.shared.types.RMap
-//import eu.vendeli.rethis.shared.types.RSet
-//import eu.vendeli.rethis.shared.types.RType
-//import eu.vendeli.rethis.shared.types.VerbatimString
-//import eu.vendeli.rethis.utils.response.parseResponse
-//import eu.vendeli.rethis.utils.response.readResponseWrapped
-//import eu.vendeli.rethis.utils.safeCast
-//import io.kotest.matchers.shouldBe
-//import io.ktor.utils.io.*
-//import io.ktor.utils.io.core.*
-//import kotlinx.io.Buffer
+// import com.ionspin.kotlin.bignum.integer.toBigInteger
+// import eu.vendeli.rethis.ReThisTestCtx
+// import eu.vendeli.rethis.shared.types.BigNumber
+// import eu.vendeli.rethis.shared.types.Bool
+// import eu.vendeli.rethis.shared.types.BulkString
+// import eu.vendeli.rethis.shared.types.F64
+// import eu.vendeli.rethis.shared.types.Int64
+// import eu.vendeli.rethis.shared.types.PlainString
+// import eu.vendeli.rethis.shared.types.Push
+// import eu.vendeli.rethis.shared.types.RArray
+// import eu.vendeli.rethis.shared.types.RMap
+// import eu.vendeli.rethis.shared.types.RSet
+// import eu.vendeli.rethis.shared.types.RType
+// import eu.vendeli.rethis.shared.types.VerbatimString
+// import eu.vendeli.rethis.utils.response.parseResponse
+// import eu.vendeli.rethis.utils.response.readResponseWrapped
+// import eu.vendeli.rethis.utils.safeCast
+// import io.kotest.matchers.shouldBe
+// import io.ktor.utils.io.*
+// import io.ktor.utils.io.core.*
+// import kotlinx.io.Buffer
 //
-//class RTypeResponseTest : ReThisTestCtx() {
+// class RTypeResponseTest : ReThisTestCtx() {
 //    @Test
 //    suspend fun `test readRedisMessage with simple string`() {
 //        val channel = ByteReadChannel {
@@ -207,4 +207,4 @@
 //
 //        return ByteReadChannel(buff)
 //    }
-//}
+// }

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/utils/RawReqUtilsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/utils/RawReqUtilsTest.kt
@@ -65,16 +65,21 @@ class RawReqUtilsTest : ReThisTestCtx() {
     suspend fun `execute block can send multi-arg commands`() {
         val key = "raw:req:kv:" + UUID.randomUUID()
         // SET key value
-        val setResp = client.execute {
-            add("SET"); add(key); add("v")
-        }.readAllUtf8()
+        val setResp = client
+            .execute {
+                add("SET")
+                add(key)
+                add("v")
+            }.readAllUtf8()
         setResp.shouldNotBeNull().shouldNotBeBlank()
         setResp shouldBe "+OK\r\n"
 
         // GET key
-        val getResp = client.execute {
-            add("GET"); add(key)
-        }.readAllUtf8()
+        val getResp = client
+            .execute {
+                add("GET")
+                add(key)
+            }.readAllUtf8()
         getResp shouldBe "\$1\r\nv\r\n"
     }
 

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/utils/RedisDistributedLockTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/utils/RedisDistributedLockTest.kt
@@ -1,0 +1,178 @@
+package eu.vendeli.rethis.utils
+
+import eu.vendeli.rethis.ReThis
+import eu.vendeli.rethis.ReThisTestCtx
+import eu.vendeli.rethis.shared.types.LockLostException
+import eu.vendeli.rethis.types.interfaces.ReDistributedLock
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import java.util.*
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class RedisDistributedLockTest : ReThisTestCtx() {
+
+    @Test
+    suspend fun `reentrancy in same coroutine increments and requires matching unlocks`() {
+        val lockName = "rethis:lock:reentrant:${UUID.randomUUID()}"
+        val lock = client.reDistributedLock(lockName)
+        val otherOwner = createClient().reDistributedLock(lockName)
+
+        // Acquire twice (reentrant)
+        lock.lock(2.seconds)
+        lock.lock(2.seconds)
+
+        // First unlock should still keep the lock held by the same owner
+        lock.unlock().shouldBeTrue()
+        // Another owner should not be able to acquire yet
+        otherOwner.tryLock(waitTime = 100.milliseconds, leaseTime = 1.seconds).shouldBeFalse()
+        // Second unlock should fully release the lock
+        lock.unlock().shouldBeTrue()
+
+        // Can be acquired again
+        otherOwner.tryLock(waitTime = 300.milliseconds, leaseTime = 1.seconds) shouldBe true
+        otherOwner.unlock().shouldBeTrue()
+    }
+
+    @Test
+    suspend fun `mutual exclusion across coroutines prevents overlap`() = coroutineScope {
+        val lockName = "rethis:lock:mutex:${UUID.randomUUID()}"
+        val lock1 = client.reDistributedLock(lockName)
+        val otherClient: ReThis = createClient()
+        val lock2 = otherClient.reDistributedLock(lockName)
+
+        val inCritical = AtomicBoolean(false)
+        var visits = 0
+
+        suspend fun critical(lock: ReDistributedLock) {
+            lock.lock(2.seconds)
+            try {
+                // detect overlap
+                val first = inCritical.compareAndSet(false, true)
+                if (!first) error("Overlapped critical section detected")
+                val before = visits
+                // simulate work
+                delay(50)
+                visits = before + 1
+            } finally {
+                inCritical.set(false)
+                lock.unlock().shouldBeTrue()
+            }
+        }
+
+        val j1 = launch { repeat(5) { critical(lock1) } }
+        val j2 = launch { repeat(5) { critical(lock2) } }
+        listOf(j1, j2).joinAll()
+
+        visits.shouldBeExactly(10)
+    }
+
+    @Test
+    suspend fun `tryLock times out when already held by another owner`() = coroutineScope {
+        val lockName = "rethis:lock:timeout:${UUID.randomUUID()}"
+        val owner1 = client.reDistributedLock(lockName)
+        val owner2 = createClient().reDistributedLock(lockName)
+
+        owner1.lock(5.seconds)
+        try {
+            val acquired = owner2.tryLock(waitTime = 100.milliseconds, leaseTime = 1.seconds)
+            acquired.shouldBeFalse()
+        } finally {
+            owner1.unlock().shouldBeTrue()
+        }
+    }
+
+    @Test
+    suspend fun `unlock frees the lock for other owners`() = coroutineScope {
+        val lockName = "rethis:lock:ttl:${UUID.randomUUID()}"
+        val owner1 = client.reDistributedLock(lockName)
+        val owner2 = createClient().reDistributedLock(lockName)
+
+        owner1.lock(300.milliseconds)
+        // While held, other owner should not acquire
+        owner2.tryLock(waitTime = 200.milliseconds, leaseTime = 1.seconds).shouldBeFalse()
+        // After release it should acquire quickly
+        owner1.unlock().shouldBeTrue()
+        val ok = owner2.tryLock(waitTime = 300.milliseconds, leaseTime = 1.seconds)
+        ok.shouldBeTrue()
+        owner2.unlock().shouldBeTrue()
+    }
+
+    @Test
+    suspend fun `non-owner cannot unlock and does not delete the key`() = coroutineScope {
+        val lockName = "rethis:lock:ownership:${UUID.randomUUID()}"
+        val owner1 = client.reDistributedLock(lockName)
+        val owner2 = createClient().reDistributedLock(lockName)
+
+        owner1.lock(2.seconds)
+        try {
+            // Another owner should fail to unlock
+            shouldThrow<LockLostException> {
+                owner2.unlock().shouldBeFalse()
+            }
+
+            // Original owner can still unlock
+            owner1.unlock().shouldBeTrue()
+        } finally {
+            // best-effort release if still held
+            runCatching { owner1.unlock() }
+        }
+    }
+
+    @Test
+    suspend fun `same instance used from two coroutines does not overlap`() = coroutineScope {
+        val lockName = "rethis:lock:same-instance:${UUID.randomUUID()}"
+        val shared = client.reDistributedLock(lockName)
+
+        val inCritical = AtomicBoolean(false)
+        var visits = 0
+
+        suspend fun critical() {
+            shared.lock(1.seconds)
+            try {
+                val first = inCritical.compareAndSet(false, true)
+                if (!first) error("Overlap with same instance!")
+                delay(40)
+                visits += 1
+            } finally {
+                inCritical.set(false)
+                shared.unlock().shouldBeTrue()
+            }
+        }
+
+        val j1 = launch { repeat(5) { critical() } }
+        val j2 = launch { repeat(5) { critical() } }
+        listOf(j1, j2).joinAll()
+        visits.shouldBeExactly(10)
+    }
+
+    @Test
+    suspend fun `withLock releases on cancellation`() = coroutineScope {
+        val lockName = "rethis:lock:cancel:${UUID.randomUUID()}"
+        val lock = client.reDistributedLock(lockName)
+
+        val job = launch {
+            lock.withLock(2.seconds) {
+                // Hold for some time, then get cancelled
+                delay(5000)
+            }
+        }
+        // Give it time to acquire
+        delay(100)
+        // Cancel the job; withLock should unlock in finally
+        job.cancel()
+        job.join()
+
+        // Now we should be able to acquire quickly
+        lock.tryLock(waitTime = 300.milliseconds, leaseTime = 1.seconds).shouldBeTrue()
+        lock.unlock().shouldBeTrue()
+    }
+}

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/utils/ResponseUtilsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/utils/ResponseUtilsTest.kt
@@ -1,22 +1,22 @@
-//package eu.vendeli.rethis.utils
+// package eu.vendeli.rethis.utils
 //
-//import com.ionspin.kotlin.bignum.integer.BigInteger
-//import com.ionspin.kotlin.bignum.integer.toBigInteger
-//import eu.vendeli.rethis.ReThisTestCtx
-//import eu.vendeli.rethis.shared.types.ReThisException
-//import eu.vendeli.rethis.utils.response.parseResponse
-//import eu.vendeli.rethis.utils.response.readListResponseTyped
-//import eu.vendeli.rethis.utils.response.readMapResponseTyped
-//import eu.vendeli.rethis.utils.response.readSimpleResponseTyped
-//import io.kotest.assertions.throwables.shouldThrow
-//import io.kotest.matchers.nulls.shouldBeNull
-//import io.kotest.matchers.shouldBe
-//import io.ktor.util.reflect.*
-//import io.ktor.utils.io.*
-//import io.ktor.utils.io.core.*
-//import kotlinx.io.Buffer
+// import com.ionspin.kotlin.bignum.integer.BigInteger
+// import com.ionspin.kotlin.bignum.integer.toBigInteger
+// import eu.vendeli.rethis.ReThisTestCtx
+// import eu.vendeli.rethis.shared.types.ReThisException
+// import eu.vendeli.rethis.utils.response.parseResponse
+// import eu.vendeli.rethis.utils.response.readListResponseTyped
+// import eu.vendeli.rethis.utils.response.readMapResponseTyped
+// import eu.vendeli.rethis.utils.response.readSimpleResponseTyped
+// import io.kotest.assertions.throwables.shouldThrow
+// import io.kotest.matchers.nulls.shouldBeNull
+// import io.kotest.matchers.shouldBe
+// import io.ktor.util.reflect.*
+// import io.ktor.utils.io.*
+// import io.ktor.utils.io.core.*
+// import kotlinx.io.Buffer
 //
-//class ResponseUtilsTest : ReThisTestCtx() {
+// class ResponseUtilsTest : ReThisTestCtx() {
 //    @Test
 //    suspend fun `test processRedisSimpleResponse with simple string`() {
 //        val channel = ByteReadChannel {
@@ -182,4 +182,4 @@
 //
 //        return ByteReadChannel(buff)
 //    }
-//}
+// }

--- a/shared/src/commonMain/kotlin/eu/vendeli/rethis/shared/types/Exceptions.kt
+++ b/shared/src/commonMain/kotlin/eu/vendeli/rethis/shared/types/Exceptions.kt
@@ -30,5 +30,11 @@ class UnexpectedResponseType(
     override val cause: Throwable? = null
 ) : ReThisException()
 
+/**
+ * Exception thrown when the lock is lost in Redis due to TTL expiry or token mismatch.
+ */
+class LockLostException(message: String) : ReThisException(message)
+
+
 inline fun processingException(cause: Throwable? = null, message: () -> String? = { null }): Nothing =
     throw DataProcessingException(message(), cause)

--- a/shared/src/commonMain/kotlin/eu/vendeli/rethis/shared/utils/RTypeUtils.kt
+++ b/shared/src/commonMain/kotlin/eu/vendeli/rethis/shared/utils/RTypeUtils.kt
@@ -150,9 +150,9 @@ fun RType.isOk() = unwrap<String>() == "OK"
 inline fun RType.handleEx(): RType =
     if (this is RType.Error) throw exception else this
 
-inline fun <reified T> RType.unwrap(): T? = run {
+inline fun <reified T> RType.unwrap(): T? {
     handleEx()
-    when {
+    return when {
         T::class == RType::class -> this as T
         T::class == RPrimitive::class -> this as? T
         this is PlainString -> if (T::class == String::class) value as T else null


### PR DESCRIPTION
* Added experimental distributed lock, try with `client.reDistributedLock`.
* Added logging entries when response is substituted with default value in specific modes (transaction, pipeline).