### PR TITLE
Correct XREADGROUP response type handling to match Redis protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("eu.vendeli:rethis:0.3.8")
+    implementation("eu.vendeli:rethis:0.3.9")
 }
 ```
 

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/codecs/stream/XReadGroupCommandCodec.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/codecs/stream/XReadGroupCommandCodec.kt
@@ -36,24 +36,26 @@ public object XReadGroupCommandCodec {
         size += 1
         buffer.writeStringArg("GROUP", charset)
         size += 1
-        buffer.writeStringArg(group, charset, )
+        buffer.writeStringArg(group, charset)
         size += 1
-        buffer.writeStringArg(consumer, charset, )
+        buffer.writeStringArg(consumer, charset)
         option.forEach { it0 ->
             when (it0) {
-                is XReadGroupOption.Block ->  {
+                is XReadGroupOption.Block -> {
                     size += 1
                     buffer.writeStringArg("BLOCK", charset)
                     size += 1
                     buffer.writeDurationArg(it0.milliseconds, charset, TimeUnit.MILLISECONDS)
                 }
-                is XReadGroupOption.Count ->  {
+
+                is XReadGroupOption.Count -> {
                     size += 1
                     buffer.writeStringArg("COUNT", charset)
                     size += 1
-                    buffer.writeLongArg(it0.count, charset, )
+                    buffer.writeLongArg(it0.count, charset)
                 }
-                is XReadGroupOption.NoAck ->  {
+
+                is XReadGroupOption.NoAck -> {
                     size += 1
                     buffer.writeStringArg("NOACK", charset)
                 }
@@ -63,11 +65,11 @@ public object XReadGroupCommandCodec {
         buffer.writeStringArg("STREAMS", charset)
         streams.key.forEach { it1 ->
             size += 1
-            buffer.writeStringArg(it1, charset, )
+            buffer.writeStringArg(it1, charset)
         }
         streams.id.forEach { it2 ->
             size += 1
-            buffer.writeStringArg(it2, charset, )
+            buffer.writeStringArg(it2, charset)
         }
 
         buffer = Buffer().apply {
@@ -94,15 +96,17 @@ public object XReadGroupCommandCodec {
     }
 
     public suspend fun decode(input: Buffer, charset: Charset): List<RType>? {
-        return when(val code = input.parseCode(RespCode.ARRAY)) {
+        return when (val code = input.parseCode(RespCode.ARRAY)) {
             RespCode.ARRAY -> {
                 ArrayRTypeDecoder.decode(input, charset, code)
             }
+
             RespCode.NULL -> {
                 null
             }
+
             else -> {
-                throw UnexpectedResponseType("Expected [ARRAY, MAP, NULL] but got $code", input.tryInferCause(code))
+                throw UnexpectedResponseType("Expected [ARRAY, NULL] but got $code", input.tryInferCause(code))
             }
         }
     }

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/codecs/stream/XReadGroupCommandCodec.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/codecs/stream/XReadGroupCommandCodec.kt
@@ -1,6 +1,6 @@
 package eu.vendeli.rethis.codecs.stream
 
-import eu.vendeli.rethis.shared.decoders.aggregate.MapRTypeDecoder
+import eu.vendeli.rethis.shared.decoders.aggregate.ArrayRTypeDecoder
 import eu.vendeli.rethis.shared.request.stream.XReadGroupKeyIds
 import eu.vendeli.rethis.shared.request.stream.XReadGroupOption
 import eu.vendeli.rethis.shared.types.*
@@ -93,14 +93,10 @@ public object XReadGroupCommandCodec {
         return request.withSlot(slot % 16384)
     }
 
-    public suspend fun decode(input: Buffer, charset: Charset): Map<String, RType>? {
-        val code = input.parseCode(RespCode.ARRAY)
-        return when(code) {
+    public suspend fun decode(input: Buffer, charset: Charset): List<RType>? {
+        return when(val code = input.parseCode(RespCode.ARRAY)) {
             RespCode.ARRAY -> {
-                MapRTypeDecoder.decode(input, charset, code)
-            }
-            RespCode.MAP -> {
-                MapRTypeDecoder.decode(input, charset, code)
+                ArrayRTypeDecoder.decode(input, charset, code)
             }
             RespCode.NULL -> {
                 null

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/stream/Xreadgroup.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/stream/Xreadgroup.kt
@@ -13,10 +13,22 @@ public suspend fun ReThis.xReadGroup(
     streams: XReadGroupKeyIds,
     vararg option: XReadGroupOption,
 ): List<RType>? {
-    val request = if(cfg.withSlots) {
-        XReadGroupCommandCodec.encodeWithSlot(charset = cfg.charset, group = group, consumer = consumer, streams = streams, option = option)
+    val request = if (cfg.withSlots) {
+        XReadGroupCommandCodec.encodeWithSlot(
+            charset = cfg.charset,
+            group = group,
+            consumer = consumer,
+            streams = streams,
+            option = option,
+        )
     } else {
-        XReadGroupCommandCodec.encode(charset = cfg.charset, group = group, consumer = consumer, streams = streams, option = option)
+        XReadGroupCommandCodec.encode(
+            charset = cfg.charset,
+            group = group,
+            consumer = consumer,
+            streams = streams,
+            option = option,
+        )
     }
     return XReadGroupCommandCodec.decode(topology.handle(request), cfg.charset)
 }

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/command/stream/Xreadgroup.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/command/stream/Xreadgroup.kt
@@ -12,7 +12,7 @@ public suspend fun ReThis.xReadGroup(
     consumer: String,
     streams: XReadGroupKeyIds,
     vararg option: XReadGroupOption,
-): Map<String, RType>? {
+): List<RType>? {
     val request = if(cfg.withSlots) {
         XReadGroupCommandCodec.encodeWithSlot(charset = cfg.charset, group = group, consumer = consumer, streams = streams, option = option)
     } else {

--- a/client/src/commonMain/kotlin/eu/vendeli/rethis/wrappers/ReThisStreamFlow.kt
+++ b/client/src/commonMain/kotlin/eu/vendeli/rethis/wrappers/ReThisStreamFlow.kt
@@ -31,7 +31,7 @@ fun ReThis.StreamFlow(
     batchSize: Long = 10,
     block: Duration = Duration.ZERO,
     acknowledge: Boolean = true,
-): Flow<Map<String, RType>> = flow {
+): Flow<List<RType>> = flow {
     val options = buildList {
         if (block.isPositive()) add(XReadGroupOption.Block(block))
         add(XReadGroupOption.Count(batchSize))

--- a/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/StreamCommandsTest.kt
+++ b/client/src/jvmTest/kotlin/eu/vendeli/rethis/commands/StreamCommandsTest.kt
@@ -131,6 +131,7 @@ class StreamCommandsTest : ReThisTestCtx() {
             ),
         )
         result shouldNotBe null
+        result shouldNotBe emptyList<RType>()
     }
 
     @Test


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other
  open [Pull Requests](https://github.com/vendelieu/re.this/pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?


## Problem

The `XReadGroupCommandCodec.decode()` method incorrectly handles `RespCode.MAP` as a valid response type for XREADGROUP command. According to the [official Redis documentation](https://redis.io/docs/latest/commands/xreadgroup/), XREADGROUP only returns two response types:

1. **Array reply** - when messages are successfully returned
2. **Nil reply** - when BLOCK option times out or no streams are available

MAP is not a valid response type for XREADGROUP.

## Changes

- Removed `RespCode.MAP` case from the decode method
- Updated error message to reflect only valid response types (ARRAY, NULL)
- Changed return type from `Map<String, RType>?` to `List<RArray>?` to accurately represent the actual Redis response structure

## Before
```kotlin
return when(code) {
    // Invalid (Array -> Map parsing causes data loss when response has 1 element in array)
    RespCode.ARRAY -> MapRTypeDecoder.decode(input, charset, code) 
    RespCode.MAP -> MapRTypeDecoder.decode(input, charset, code)  // Invalid
    RespCode.NULL -> null
    else -> throw UnexpectedResponseType("Expected [ARRAY, MAP, NULL] but got $code", ...)
}
```

## After
```kotlin
return when(code) {
    RespCode.ARRAY -> ArrayRTypeDecoder.decode(input, charset, code)
    RespCode.NULL -> null
    else -> throw UnexpectedResponseType("Expected [ARRAY, NULL] but got $code", ...)
}
```